### PR TITLE
Update variable type for FrontDoor WAF module

### DIFF
--- a/modules/azurerm/Application-Gateway/variables.tf
+++ b/modules/azurerm/Application-Gateway/variables.tf
@@ -152,9 +152,9 @@ variable "ssl_policy_name" {
 }
 
 variable "appgw_backend_http_settings" {
-  default     = [{}]
+  default     = [{ default = "default" }]
   description = "List of maps including backend http settings configurations"
-  type        = list(map(string))
+  type        = any
 }
 
 variable "appgw_http_listeners" {
@@ -164,9 +164,9 @@ variable "appgw_http_listeners" {
 }
 
 variable "appgw_backend_pools" {
-  default     = [{}]
+  default     = [{ default = "default" }]
   description = "List of maps including backend pool configurations"
-  type        = list(map(string))
+  type        = any
 }
 
 variable "ssl_certificates_configs" {

--- a/modules/azurerm/FrontDoor-WAF/variables.tf
+++ b/modules/azurerm/FrontDoor-WAF/variables.tf
@@ -31,5 +31,5 @@ variable "tags" {
 
 variable "front_door_waf_object" {
   description = "Front Door WAF Object configuration"
-  type        = object({})
+  type        = map(any)
 }


### PR DESCRIPTION
**Changes**

This PR updates the variable type to string for the following modules:

1. `modules/azurerm/FrontDoor-WAF`
2. `modules/azurerm/Application-Gateway`



