### PR TITLE
[main] Parameterize resource abbreviation for Alert module

### DIFF
--- a/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/monitor_activity_log_administrative_alerts.tf
+++ b/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/monitor_activity_log_administrative_alerts.tf
@@ -12,7 +12,7 @@
 resource "azurerm_monitor_activity_log_alert" "monitor_activity_log_administrative_alert" {
   for_each            = var.activity_log_administrative_alerts
   tags                = var.tags
-  name                = join("-", ["ala", each.value.monitor_activity_log_alert_name])
+  name                = join("-", [var.monitor_activity_log_alert_abbreviation, each.value.monitor_activity_log_alert_name])
   resource_group_name = var.resource_group_name
   scopes              = each.value.scopes
   description         = each.value.description

--- a/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/variables.tf
+++ b/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/variables.tf
@@ -37,3 +37,9 @@ variable "activity_log_administrative_alerts" {
     resource_id             = string
   }))
 }
+
+variable "monitor_metric_alert_abbreviation" {
+  description = "The abbreviation of the resource name."
+  type        = string
+  default     = "ala"
+}

--- a/modules/azurerm/Monitor-Log-Alerts/monitor_log_alerts.tf
+++ b/modules/azurerm/Monitor-Log-Alerts/monitor_log_alerts.tf
@@ -12,7 +12,7 @@
 resource "azurerm_monitor_activity_log_alert" "monitor_recommendation_alert" {
   for_each            = var.recommendation_alerts
   tags                = var.tags
-  name                = join("-", ["ala", each.value.alert_name])
+  name                = join("-", [var.monitor_activity_log_alert_abbreviation, each.value.alert_name])
   resource_group_name = var.resource_group_name
   scopes              = each.value.scopes
   description         = each.value.description
@@ -31,7 +31,7 @@ resource "azurerm_monitor_activity_log_alert" "monitor_recommendation_alert" {
 resource "azurerm_monitor_activity_log_alert" "monitor_activity_log_alert" {
   for_each            = var.activity_log_alerts
   tags                = var.tags
-  name                = join("-", ["ala", each.value.alert_name])
+  name                = join("-", [var.monitor_activity_log_alert_abbreviation, each.value.alert_name])
   resource_group_name = var.resource_group_name
   scopes              = each.value.scopes
   description         = each.value.description
@@ -50,7 +50,7 @@ resource "azurerm_monitor_activity_log_alert" "monitor_activity_log_alert" {
 resource "azurerm_monitor_activity_log_alert" "monitor_resource_health_alert" {
   for_each            = var.resource_health_alerts
   tags                = var.tags
-  name                = join("-", ["ala", each.value.alert_name])
+  name                = join("-", [var.monitor_activity_log_alert_abbreviation, each.value.alert_name])
   resource_group_name = var.resource_group_name
   scopes              = each.value.scopes
   enabled             = each.value.query_enabled
@@ -78,7 +78,7 @@ resource "azurerm_monitor_activity_log_alert" "monitor_resource_health_alert" {
 resource "azurerm_monitor_activity_log_alert" "monitor_service_health_alert" {
   for_each            = var.service_health_alerts
   tags                = var.tags
-  name                = join("-", ["ala", each.value.alert_name])
+  name                = join("-", [var.monitor_activity_log_alert_abbreviation, each.value.alert_name])
   resource_group_name = var.resource_group_name
   scopes              = each.value.scopes
   enabled             = each.value.query_enabled
@@ -101,7 +101,7 @@ resource "azurerm_monitor_activity_log_alert" "monitor_service_health_alert" {
 resource "azurerm_monitor_activity_log_alert" "monitor_specific_service_health_alert" {
   for_each            = var.specific_service_health_alerts
   tags                = var.tags
-  name                = join("-", ["ala", each.value.alert_name])
+  name                = join("-", [var.monitor_activity_log_alert_abbreviation, each.value.alert_name])
   resource_group_name = var.resource_group_name
   scopes              = each.value.scopes
   enabled             = each.value.query_enabled

--- a/modules/azurerm/Monitor-Log-Alerts/variables.tf
+++ b/modules/azurerm/Monitor-Log-Alerts/variables.tf
@@ -97,3 +97,9 @@ variable "specific_service_health_alerts" {
     targetServices          = list(string)
   }))
 }
+
+variable "monitor_metric_alert_abbreviation" {
+  description = "The abbreviation of the resource name."
+  type        = string
+  default     = "ala"
+}

--- a/modules/azurerm/Monitor-Metric-Alerts/monitor_metrics_alerts.tf
+++ b/modules/azurerm/Monitor-Metric-Alerts/monitor_metrics_alerts.tf
@@ -11,7 +11,7 @@
 
 resource "azurerm_monitor_metric_alert" "monitor_metric_alert_with_2_dimensions" {
   for_each             = var.metric_alerts_with_2_dimensions
-  name                 = join("-", ["ma", each.value.alert_name])
+  name                 = join("-", [var.monitor_metric_alert_abbreviation, each.value.alert_name])
   resource_group_name  = var.resource_group_name
   tags                 = var.tags
   scopes               = each.value.scopes
@@ -49,7 +49,7 @@ resource "azurerm_monitor_metric_alert" "monitor_metric_alert_with_2_dimensions"
 
 resource "azurerm_monitor_metric_alert" "monitor_metric_alert_with_1_dimension" {
   for_each             = var.metric_alerts_with_1_dimension
-  name                 = join("-", ["ma", each.value.alert_name])
+  name                 = join("-", [var.monitor_metric_alert_abbreviation, each.value.alert_name])
   resource_group_name  = var.resource_group_name
   tags                 = var.tags
   scopes               = each.value.scopes
@@ -81,7 +81,7 @@ resource "azurerm_monitor_metric_alert" "monitor_metric_alert_with_1_dimension" 
 
 resource "azurerm_monitor_metric_alert" "monitor_metric_alert" {
   for_each                 = var.metric_alerts
-  name                     = join("-", ["ma", each.value.alert_name])
+  name                     = join("-", [var.monitor_metric_alert_abbreviation, each.value.alert_name])
   resource_group_name      = var.resource_group_name
   tags                     = var.tags
   scopes                   = each.value.scopes

--- a/modules/azurerm/Monitor-Metric-Alerts/variables.tf
+++ b/modules/azurerm/Monitor-Metric-Alerts/variables.tf
@@ -95,3 +95,9 @@ variable "metric_alerts" {
     criteria_threshold        = number
   }))
 }
+
+variable "monitor_metric_alert_abbreviation" {
+  description = "The abbreviation of the resource name."
+  type        = string
+  default     = "ma"
+}


### PR DESCRIPTION
## Purpose
> This is to parameterize the resource abbreviations
## Modules Changed
```
Monitor-Activity-Log-Administrative-Alerts
Monitor-Log-Alerts
Monitor-Metric-Alerts
```
**Note:** The default values are set with the existing abbreviation values. Hence, this change will not impact the existing usages.