### PR TITLE
[main] Fix variable name

### DIFF
--- a/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/variables.tf
+++ b/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/variables.tf
@@ -38,7 +38,7 @@ variable "activity_log_administrative_alerts" {
   }))
 }
 
-variable "monitor_metric_alert_abbreviation" {
+variable "monitor_activity_log_alert_abbreviation" {
   description = "The abbreviation of the resource name."
   type        = string
   default     = "ala"

--- a/modules/azurerm/Monitor-Log-Alerts/variables.tf
+++ b/modules/azurerm/Monitor-Log-Alerts/variables.tf
@@ -98,7 +98,7 @@ variable "specific_service_health_alerts" {
   }))
 }
 
-variable "monitor_metric_alert_abbreviation" {
+variable "monitor_activity_log_alert_abbreviation" {
   description = "The abbreviation of the resource name."
   type        = string
   default     = "ala"


### PR DESCRIPTION
## Purpose
> This PR is to fix the varibale name mismatch with the resource
## Module Changes
Module: `Monitor-Log-Alerts` and `Monitor-Activity-Log-Administrative-Alerts`
Renamed variable: `monitor_metric_alert_abbreviation` to `monitor_activity_log_alert_abbreviation`