### PR TITLE
[main] Add AAD Login extension for VMSS

### DIFF
--- a/modules/azurerm/VMSS-Linux/vmss.tf
+++ b/modules/azurerm/VMSS-Linux/vmss.tf
@@ -76,4 +76,8 @@ resource "azurerm_linux_virtual_machine_scale_set" "linux_virtual_machine_scale_
       load_balancer_backend_address_pool_ids       = var.load_balancer_backend_address_pool_ids
     }
   }
+
+  identity {
+    type = "SystemAssigned"
+  }
 }

--- a/modules/azurerm/VMSS-Linux/vmss_extension.tf
+++ b/modules/azurerm/VMSS-Linux/vmss_extension.tf
@@ -1,0 +1,23 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_virtual_machine_scale_set_extension" "ad_login_virtual_machine_extension" {
+  name                       = "AADSSHLoginForLinux"
+  virtual_machine_id         = azurerm_linux_virtual_machine_scale_set.linux_virtual_machine_scale_set.id
+  publisher                  = "Microsoft.Azure.ActiveDirectory"
+  type                       = "AADSSHLoginForLinux"
+  type_handler_version       = "1.0"
+  auto_upgrade_minor_version = true
+
+  depends_on = [
+    azurerm_linux_virtual_machine_scale_set.linux_virtual_machine_scale_set
+  ]
+}


### PR DESCRIPTION
## Purpose
> This is to add Azure Active Directory Login Extension to the VMSS.
## Module(s) Changed
`VMSS-Linux`

**Note**: AAD Login Extension need managed identity and access to the internet to install the public dists.