### PR TITLE
[main] Rename resource property for module VMSS Linux

### DIFF
--- a/modules/azurerm/VMSS-Linux/vmss_extension.tf
+++ b/modules/azurerm/VMSS-Linux/vmss_extension.tf
@@ -10,12 +10,12 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_virtual_machine_scale_set_extension" "ad_login_virtual_machine_extension" {
-  name                       = "AADSSHLoginForLinux"
-  virtual_machine_id         = azurerm_linux_virtual_machine_scale_set.linux_virtual_machine_scale_set.id
-  publisher                  = "Microsoft.Azure.ActiveDirectory"
-  type                       = "AADSSHLoginForLinux"
-  type_handler_version       = "1.0"
-  auto_upgrade_minor_version = true
+  name                         = "AADSSHLoginForLinux"
+  virtual_machine_scale_set_id = azurerm_linux_virtual_machine_scale_set.linux_virtual_machine_scale_set.id
+  publisher                    = "Microsoft.Azure.ActiveDirectory"
+  type                         = "AADSSHLoginForLinux"
+  type_handler_version         = "1.0"
+  auto_upgrade_minor_version   = true
 
   depends_on = [
     azurerm_linux_virtual_machine_scale_set.linux_virtual_machine_scale_set


### PR DESCRIPTION
## Purpose
> This PR fixes the issue with resource property name for the module `azurerm_virtual_machine_scale_set_extension`.
## Module(s) Changed
`VMSS-Linux`