### PR TITLE
[main] Rename resource property for module Static IP VM

### DIFF
--- a/modules/azurerm/Static-IP-Custom-Virtual-Machine/virtual_machine_extension.tf
+++ b/modules/azurerm/Static-IP-Custom-Virtual-Machine/virtual_machine_extension.tf
@@ -20,12 +20,12 @@ resource "azurerm_virtual_machine_extension" "azure_monitor_agent_extension" {
 }
 
 resource "azurerm_virtual_machine_extension" "ad_login_virtual_machine_extension" {
-  name                         = "AADSSHLoginForLinux"
-  virtual_machine_scale_set_id = azurerm_linux_virtual_machine.static_ip_linux_virtual_machine.id
-  publisher                    = "Microsoft.Azure.ActiveDirectory"
-  type                         = "AADSSHLoginForLinux"
-  type_handler_version         = "1.0"
-  auto_upgrade_minor_version   = true
+  name                       = "AADSSHLoginForLinux"
+  virtual_machine_id         = azurerm_linux_virtual_machine.static_ip_linux_virtual_machine.id
+  publisher                  = "Microsoft.Azure.ActiveDirectory"
+  type                       = "AADSSHLoginForLinux"
+  type_handler_version       = "1.0"
+  auto_upgrade_minor_version = true
 
   depends_on = [
     azurerm_linux_virtual_machine.static_ip_linux_virtual_machine


### PR DESCRIPTION
## Purpose
> This PR fixes the issue with resource property name for the module `azurerm_virtual_machine_extension `.
## Module(s) Changed
`Static-IP-Custom-Virtual-Machine`