### PR TITLE
[main] Add lifecycle ignore for identity block

### DIFF
--- a/modules/azurerm/Application-Gateway/application_gateway.tf
+++ b/modules/azurerm/Application-Gateway/application_gateway.tf
@@ -271,7 +271,8 @@ resource "azurerm_application_gateway" "app_gateway" {
       ssl_certificate,
       redirect_configuration,
       tags,
-      trusted_root_certificate
+      trusted_root_certificate,
+      identity
     ]
   }
 }


### PR DESCRIPTION
## Purpose
> Application gateway needs a managed identity to bind an existing client SSL certificate from a key vault. This client certificate is added from the listner configuration. Hence, ignoring the identity block from the lifecycle since the listner configurations are ignored from the lifecycle as well.
## Module(s) Changed
`Application-Gateway`