### PR TITLE
Add Azure Open AI Service module

### DIFF
--- a/modules/azurerm/Azure-OpenAI-Service/azure_openai_service.tf
+++ b/modules/azurerm/Azure-OpenAI-Service/azure_openai_service.tf
@@ -13,7 +13,7 @@ resource "azurerm_cognitive_account" "azure_openai_account" {
   kind                               = var.kind
   location                           = var.location
   resource_group_name                = var.resource_group_name
-  name                               = join("-", ["aoaica", var.cognitive_account_name])
+  name                               = join("-", [var.cognitive_account_abbreviation, var.cognitive_account_name])
   sku_name                           = var.account_sku_name
   dynamic_throttling_enabled         = var.dynamic_throttling_enabled
   outbound_network_access_restricted = var.outbound_network_access_restricted
@@ -23,7 +23,7 @@ resource "azurerm_cognitive_account" "azure_openai_account" {
 
 resource "azurerm_cognitive_deployment" "azure_openai_deployment" {
   cognitive_account_id   = azurerm_cognitive_account.azure_openai_account.id
-  name                   = join("-", ["aoaicd", var.cognitive_deployment_name])
+  name                   = join("-", [var.cognitive_deployment_abbreviation, var.cognitive_deployment_name])
   rai_policy_name        = var.rai_policy_name
   version_upgrade_option = var.version_upgrade_option
 

--- a/modules/azurerm/Azure-OpenAI-Service/azure_openai_service.tf
+++ b/modules/azurerm/Azure-OpenAI-Service/azure_openai_service.tf
@@ -1,0 +1,39 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_cognitive_account" "azure_openai_account" {
+  kind                               = var.kind
+  location                           = var.location
+  resource_group_name                = var.resource_group_name
+  name                               = join("-", ["aoaica", var.cognitive_account_name])
+  sku_name                           = var.account_sku_name
+  dynamic_throttling_enabled         = var.dynamic_throttling_enabled
+  outbound_network_access_restricted = var.outbound_network_access_restricted
+  public_network_access_enabled      = var.public_network_access_enabled
+  tags                               = var.tags
+}
+
+resource "azurerm_cognitive_deployment" "azure_openai_deployment" {
+  cognitive_account_id   = azurerm_cognitive_account.azure_openai_account.id
+  name                   = join("-", ["aoaicd", var.cognitive_deployment_name])
+  rai_policy_name        = var.rai_policy_name
+  version_upgrade_option = var.version_upgrade_option
+
+  model {
+    format  = var.cognitive_model_format
+    name    = var.cognitive_model_name
+    version = var.cognitive_model_version
+  }
+  scale {
+    type     = var.deployment_sku_scale_type
+    capacity = var.deployment_sku_scale_capacity
+  }
+}

--- a/modules/azurerm/Azure-OpenAI-Service/outputs.tf
+++ b/modules/azurerm/Azure-OpenAI-Service/outputs.tf
@@ -1,0 +1,35 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+output "azure_openai_account_id" {
+  depends_on = [azurerm_cognitive_account.azure_openai_account]
+  value      = azurerm_cognitive_account.azure_openai_account.id
+}
+
+output "azure_openai_account_endpoint" {
+  depends_on = [azurerm_cognitive_account.azure_openai_account]
+  value      = azurerm_cognitive_account.azure_openai_account.endpoint
+}
+
+output "azure_openai_account_primary_access_key" {
+  depends_on = [azurerm_cognitive_account.azure_openai_account]
+  value      = azurerm_cognitive_account.azure_openai_account.primary_access_key
+}
+
+output "azure_openai_account_secondary_access_key" {
+  depends_on = [azurerm_cognitive_account.azure_openai_account]
+  value      = azurerm_cognitive_account.azure_openai_account.secondary_access_key
+}
+
+output "azure_openai_deployment_id" {
+  depends_on = [azurerm_cognitive_deployment.azure_openai_deployment]
+  value      = azurerm_cognitive_deployment.azure_openai_deployment.id
+}

--- a/modules/azurerm/Azure-OpenAI-Service/variables.tf
+++ b/modules/azurerm/Azure-OpenAI-Service/variables.tf
@@ -25,6 +25,12 @@ variable "resource_group_name" {
   type        = string
 }
 
+variable "cognitive_account_abbreviation" {
+  description = "The abbreviation for the name of the Azure Cognitive account."
+  type        = string
+  default     = "oai"
+}
+
 variable "cognitive_account_name" {
   description = "The name of the Azure Cognitive account."
   type        = string
@@ -51,6 +57,12 @@ variable "public_network_access_enabled" {
   description = "Specifies whether public network access is allowed for the Cognitive Account."
   type        = bool
   default     = false
+}
+
+variable "cognitive_deployment_abbreviation" {
+  description = "The abbreviation for the name of the Azure Cognitive Deployment."
+  type        = string
+  default     = "oai"
 }
 
 variable "cognitive_deployment_name" {

--- a/modules/azurerm/Azure-OpenAI-Service/variables.tf
+++ b/modules/azurerm/Azure-OpenAI-Service/variables.tf
@@ -1,0 +1,102 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+variable "kind" {
+  description = "Specifies the type of Cognitive Service Account that should be created."
+  type        = string
+  default     = "OpenAI"
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group name"
+  type        = string
+}
+
+variable "cognitive_account_name" {
+  description = "The name of the Azure Cognitive account."
+  type        = string
+}
+
+variable "account_sku_name" {
+  description = "The SKU name of the Azure Cognitive account."
+  type        = string
+}
+
+variable "dynamic_throttling_enabled" {
+  description = "Specifies whether to enable the dynamic throttling for this Cognitive Service Account."
+  type        = bool
+  default     = false
+}
+
+variable "outbound_network_access_restricted" {
+  description = "Specifies whether outbound network access is restricted for the Cognitive Account"
+  type        = bool
+  default     = true
+}
+
+variable "public_network_access_enabled" {
+  description = "Specifies whether public network access is allowed for the Cognitive Account."
+  type        = bool
+  default     = false
+}
+
+variable "cognitive_deployment_name" {
+  description = "The name of the Cognitive Services Account Deployment."
+  type        = string
+}
+
+variable "rai_policy_name" {
+  description = "Optional Parameter for the name of the RAI policy."
+  type        = string
+  default     = null
+}
+
+variable "version_upgrade_option" {
+  description = "Deployment model version upgrade option."
+  type        = string
+  default     = "NoAutoUpgrade"
+}
+
+variable "cognitive_model_format" {
+  description = "The format of the Cognitive Services Account Deployment model."
+  type        = string
+  default     = "OpenAI"
+}
+
+variable "cognitive_model_name" {
+  description = "The name of the Cognitive Services Account Deployment model."
+  type        = string
+}
+
+variable "cognitive_model_version" {
+  description = "The version of Cognitive Services Account Deployment model."
+  type        = string
+}
+
+variable "deployment_sku_scale_type" {
+  description = "The name of the SKU. Ex - Standard or P3."
+  type        = string
+}
+
+variable "deployment_sku_scale_capacity" {
+  description = " Tokens-per-Minute (TPM). The unit of measure for this field is in the thousands of Tokens-per-Minute."
+  type        = string
+}
+
+variable "tags" {
+  description = "Default tag list"
+  type        = map(string)
+}

--- a/modules/azurerm/Azure-OpenAI-Service/versions.tf
+++ b/modules/azurerm/Azure-OpenAI-Service/versions.tf
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.52.0"
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
The purpose of this PR is to add a terraform module for deploying Azure OpenAI Service.

The module consists of the azurerm_cognitive_account resource[1] and the azurerm_cognitive_deployment resource[2]  in the azurerm provider[3].

The azurerm_cognitive_account creates the Azure coginitive account and the azurerm_cognitive_deployment deploys the Open AI model.

[1] https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cognitive_account
[2] https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cognitive_deployment
[3] https://registry.terraform.io/providers/hashicorp/azurerm