### PR TITLE
Bump azurerm required version in azure open-ai service

### DIFF
--- a/modules/azurerm/Azure-OpenAI-Service/versions.tf
+++ b/modules/azurerm/Azure-OpenAI-Service/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.52.0"
+      version = ">= 3.80.0"
     }
   }
 }


### PR DESCRIPTION
## Purpose
Bump azurerm required version to 3.80.0 in azure open-ai service

