### PR TITLE
Update azure open ai service module to contain custom sub domain name

### DIFF
--- a/modules/azurerm/Azure-OpenAI-Service/azure_openai_service.tf
+++ b/modules/azurerm/Azure-OpenAI-Service/azure_openai_service.tf
@@ -18,6 +18,7 @@ resource "azurerm_cognitive_account" "azure_openai_account" {
   dynamic_throttling_enabled         = var.dynamic_throttling_enabled
   outbound_network_access_restricted = var.outbound_network_access_restricted
   public_network_access_enabled      = var.public_network_access_enabled
+  custom_subdomain_name              = join("-", [var.cognitive_account_abbreviation, var.custom_subdomain_name])
   tags                               = var.tags
 }
 

--- a/modules/azurerm/Azure-OpenAI-Service/variables.tf
+++ b/modules/azurerm/Azure-OpenAI-Service/variables.tf
@@ -59,6 +59,11 @@ variable "public_network_access_enabled" {
   default     = false
 }
 
+variable "custom_subdomain_name" {
+  description = "The subdomain name used for token-based authentication."
+  type        = string
+}
+
 variable "cognitive_deployment_abbreviation" {
   description = "The abbreviation for the name of the Azure Cognitive Deployment."
   type        = string


### PR DESCRIPTION
## Purpose
The custom_subdomain_name[1] argument is added to the Azure-OpenAI-Service module

[1] https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cognitive_account#custom_subdomain_name