### PR TITLE
Add DevOps Elastic Pool Module

### DIFF
--- a/modules/azuredevops/Elastic-Pool/elastic_pool.tf
+++ b/modules/azuredevops/Elastic-Pool/elastic_pool.tf
@@ -1,11 +1,20 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained
-# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-# You may not alter or remove any copyright or other notice from copies of this content.
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # --------------------------------------------------------------------------------------
 

--- a/modules/azuredevops/Elastic-Pool/elastic_pool.tf
+++ b/modules/azuredevops/Elastic-Pool/elastic_pool.tf
@@ -1,0 +1,25 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azuredevops_elastic_pool" "elastic_pool" {
+  name                   = var.pool_name
+  service_endpoint_id    = var.service_endpoint_id
+  service_endpoint_scope = var.service_endpoint_scope
+  desired_idle           = var.desired_idle
+  max_capacity           = var.max_capacity
+  project_id             = var.project_id
+  azure_resource_id      = var.vmss_resource_id
+  recycle_after_each_use = var.recycle_after_each_use
+  time_to_live_minutes   = var.time_to_live_minutes
+  agent_interactive_ui   = var.agent_interactive_ui
+  auto_provision         = var.auto_provision
+  auto_update            = var.auto_update
+}

--- a/modules/azuredevops/Elastic-Pool/outputs.tf
+++ b/modules/azuredevops/Elastic-Pool/outputs.tf
@@ -1,0 +1,16 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+output "elastic_pool_id" {
+  description = "The ID of the elastic pool."
+  depends_on  = [azuredevops_elastic_pool.elastic_pool]
+  value       = azuredevops_elastic_pool.elastic_pool.id
+}

--- a/modules/azuredevops/Elastic-Pool/outputs.tf
+++ b/modules/azuredevops/Elastic-Pool/outputs.tf
@@ -1,11 +1,20 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained
-# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-# You may not alter or remove any copyright or other notice from copies of this content.
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # --------------------------------------------------------------------------------------
 

--- a/modules/azuredevops/Elastic-Pool/variables.tf
+++ b/modules/azuredevops/Elastic-Pool/variables.tf
@@ -1,11 +1,20 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained
-# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-# You may not alter or remove any copyright or other notice from copies of this content.
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # --------------------------------------------------------------------------------------
 

--- a/modules/azuredevops/Elastic-Pool/variables.tf
+++ b/modules/azuredevops/Elastic-Pool/variables.tf
@@ -1,0 +1,75 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+variable "pool_name" {
+  description = "The name of the elastic pool."
+  type        = string
+}
+
+variable "service_endpoint_id" {
+  description = "The ID of the service endpoint."
+  type        = string
+}
+variable "service_endpoint_scope" {
+  description = "The scope of the service endpoint."
+  type        = string
+}
+
+variable "desired_idle" {
+  description = "Number of agents to keep on standby."
+  type        = number
+}
+
+variable "max_capacity" {
+  description = "Maximum number of virtual machines in the scale set"
+  type        = number
+}
+
+variable "project_id" {
+  description = "The ID of the project where a new Elastic Pool will be created."
+  default     = null
+  type        = string
+}
+
+variable "vmss_resource_id" {
+  description = "The ID of the VMSS resource."
+  type        = string
+}
+
+variable "recycle_after_each_use" {
+  description = "Tear down virtual machines after every use."
+  default     = false
+  type        = bool
+}
+
+variable "time_to_live_minutes" {
+  description = "Delay in minutes before deleting excess idle agents."
+  default     = 30
+  type        = number
+}
+
+variable "agent_interactive_ui" {
+  description = "Set whether agents should be configured to run with interactive UI."
+  default     = false
+  type        = bool
+}
+
+variable "auto_provision" {
+  description = "Specifies whether a queue should be automatically provisioned for each project collection."
+  default     = false
+  type        = bool
+}
+
+variable "auto_update" {
+  description = "Specifies whether or not agents within the pool should be automatically updated."
+  default     = true
+  type        = bool
+}

--- a/modules/azuredevops/Elastic-Pool/versions.tf
+++ b/modules/azuredevops/Elastic-Pool/versions.tf
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azuredevops = {
+      source  = "microsoft/azuredevops"
+      version = ">= 0.7.0"
+    }
+  }
+}

--- a/modules/azuredevops/Elastic-Pool/versions.tf
+++ b/modules/azuredevops/Elastic-Pool/versions.tf
@@ -1,11 +1,20 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained
-# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-# You may not alter or remove any copyright or other notice from copies of this content.
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # --------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Purpose

Add DevOps Elastic Pool Terraform module to onboard Virtual Machine Scale Sets as Agent Pools in the Azure DevOps. This is a wrapped module of https://registry.terraform.io/providers/microsoft/azuredevops/0.7.0/docs/resources/elastic_pool