### PR TITLE
Add Route Table Association Dependency to AKS Firewall

### DIFF
--- a/modules/azurerm/AKS-Firewall/aks_cluster.tf
+++ b/modules/azurerm/AKS-Firewall/aks_cluster.tf
@@ -27,7 +27,7 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
   workload_identity_enabled           = var.workload_identity_enabled
   oidc_issuer_enabled                 = var.oidc_issuer_enabled
   tags                                = var.tags
-  depends_on                          = [azurerm_subnet.aks_node_pool_subnet]
+  depends_on                          = [azurerm_subnet.aks_node_pool_subnet, azurerm_subnet_route_table_association.subnet_rt_association]
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
## Purpose

Add the AKS Subnet Route Table association as a dependency to the creation of AKS Cluster in the AKS-Firewall module. This helps preventing the following error behaviour when spinning a new environment.

```log
Error: creating Managed Cluster (Subscription: "xxxx"
Resource Group Name: "rg-xxxxx"
Managed Cluster Name: "aks-xxxx"): managedclusters.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="ExistingRouteTableNotAssociatedWithSubnet" Message="An existing route table has not been associated with subnet /subscriptions/xxxx/resourceGroups/rg-xxx/providers/Microsoft.Network/virtualNetworks/vnet-xxxx/subnets/snet-xxxx. Please update the route table association"
```