### PR TITLE
Add Backend Pool Settings to Configure FrontDoor Timeouts

### DIFF
--- a/modules/azapi/FrontDoor/frontdoor.tf
+++ b/modules/azapi/FrontDoor/frontdoor.tf
@@ -89,6 +89,12 @@ resource "azapi_resource" "frontdoor" {
         }
       ]
 
+      # Configure Backend Pools Settings
+      backendPoolsSettings = {
+        enforceCertificateNameCheck = var.enforce_certificate_name_check
+        sendRecvTimeoutSeconds      = var.send_recv_timeout_seconds
+      }
+
       # Configure Backend Pool
       backendPools = [
         for pool in var.backend_pools :

--- a/modules/azapi/FrontDoor/variables.tf
+++ b/modules/azapi/FrontDoor/variables.tf
@@ -96,6 +96,18 @@ variable "health_probe_abbreviation" {
   default     = "hp"
 }
 
+variable "enforce_certificate_name_check" {
+  description = "Enforce certificate name check."
+  type        = string
+  default     = "Enabled"
+}
+
+variable "send_recv_timeout_seconds" {
+  description = "The send and receive timeout in seconds."
+  type        = number
+  default     = 30
+}
+
 variable "backend_pools" {
   description = "A list of backend pools to be associated with the Front Door."
   type = list(object({


### PR DESCRIPTION
## Purpose

Add backend pool settings block to configure the FrontDoor timeouts. This configuration applies to all Backend pools that are configured in the respective FrontDoor resource
