### PR TITLE
Remove retentions for storage log archive from diagnostic settings module

### DIFF
--- a/modules/azurerm/Resource-Monitoring-Diagnostic-Setting/locals.tf
+++ b/modules/azurerm/Resource-Monitoring-Diagnostic-Setting/locals.tf
@@ -1,21 +1,28 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained
-# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-# You may not alter or remove any copyright or other notice from copies of this content.
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # --------------------------------------------------------------------------------------
 
 locals {
-  user_provided_logs_settings      = { for s in var.required_log_categories : s.category_name => s.retention_period }
-  user_provided_metrics_settings   = { for s in var.required_metric_categories : s.category_name => s.retention_period }
-  default_logs_retention_period    = var.all_log_types_enabled.enabled ? var.all_log_types_enabled.retention_period : 0
-  default_metrics_retention_period = var.all_metrics_enabled.enabled ? var.all_metrics_enabled.retention_period : 0
-  updated_default_logs_settings    = { for s in sort(data.azurerm_monitor_diagnostic_categories.default.logs) : s => local.default_logs_retention_period }
-  updated_default_metrics_settings = { for s in sort(data.azurerm_monitor_diagnostic_categories.default.metrics) : s => local.default_metrics_retention_period }
+  user_provided_logs_settings      = { for s in var.required_log_categories : s.category_name => true }
+  user_provided_metrics_settings   = { for s in var.required_metric_categories : s.category_name => true }
+  updated_default_logs_settings    = { for s in sort(data.azurerm_monitor_diagnostic_categories.default.logs) : s => var.all_log_types_enabled }
+  updated_default_metrics_settings = { for s in sort(data.azurerm_monitor_diagnostic_categories.default.metrics) : s => var.all_metrics_enabled }
   all_logs_settings                = merge(local.updated_default_logs_settings, local.user_provided_logs_settings)
   all_metrics_settings             = merge(local.updated_default_metrics_settings, local.user_provided_metrics_settings)
 }

--- a/modules/azurerm/Resource-Monitoring-Diagnostic-Setting/resource_monitoring_diagnostic_setting.tf
+++ b/modules/azurerm/Resource-Monitoring-Diagnostic-Setting/resource_monitoring_diagnostic_setting.tf
@@ -1,11 +1,20 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained
-# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-# You may not alter or remove any copyright or other notice from copies of this content.
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # --------------------------------------------------------------------------------------
 
@@ -22,29 +31,18 @@ resource "azurerm_monitor_diagnostic_setting" "resource_monitoring_diagnostic_se
 
   dynamic "log" {
     for_each = local.all_logs_settings
-
     content {
       category = log.key
-      enabled  = log.value == 0 ? false : true
-
-      retention_policy {
-        enabled = log.value == 0 ? false : true
-        days    = log.value
-      }
+      enabled  = log.value
     }
   }
 
   dynamic "metric" {
     for_each = local.all_metrics_settings
-
     content {
       category = metric.key
-      enabled  = metric.value == 0 ? false : true
+      enabled  = metric.value
 
-      retention_policy {
-        enabled = metric.value == 0 ? false : true
-        days    = metric.value
-      }
     }
   }
 }

--- a/modules/azurerm/Resource-Monitoring-Diagnostic-Setting/variables.tf
+++ b/modules/azurerm/Resource-Monitoring-Diagnostic-Setting/variables.tf
@@ -1,34 +1,43 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained
-# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-# You may not alter or remove any copyright or other notice from copies of this content.
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # --------------------------------------------------------------------------------------
 
 variable "log_setting_name" {
-  description = "Name of the Diagnostic Setting"
   type        = string
+  description = "Diagnostic Setting Name"
 }
 
 variable "target_resource_id" {
-  description = "Azure resource ID for target resource to extract logs"
   type        = string
+  description = "Azure resource ID for target resource to extract logs"
 }
 
 variable "archival_locations" {
-  default = {
-    archival_storage_account_id = "",
-    log_analytics_workspace_id  = ""
-  }
-  description = "Locations to extract Log files to keep empty if not required"
   type = object({
     archival_storage_account_id = string,
     log_analytics_workspace_id  = string
   })
+  description = "Locations to extract Log files to keep empty if not required"
+  default = {
+    archival_storage_account_id = "",
+    log_analytics_workspace_id  = ""
+  }
   validation {
     condition     = var.archival_locations.archival_storage_account_id != "" || var.archival_locations.log_analytics_workspace_id != ""
     error_message = "Please specify at least one locations to send Logs."
@@ -36,53 +45,45 @@ variable "archival_locations" {
 }
 
 variable "sub_service_id" {
-  default     = ""
-  description = "Path to access Sub service (OPTIONAL)"
   type        = string
+  description = "Path to access Sub service (OPTIONAL)"
+  default     = ""
 }
 
 variable "required_metric_categories" {
-  default     = []
-  description = "Metrics to be extracted from the resource"
   type = list(object(
     {
-      category_name : string,
-      retention_period : number
+      category_name : string
     }
   ))
+  description = "Metrics to be extracted from the resource"
+  default     = []
 }
 
 variable "required_log_categories" {
-  default     = []
-  description = "Logs to be extracted from the resource"
   type = list(object(
     {
-      category_name : string,
-      retention_period : number
+      category_name : string
     }
   ))
+  description = "Logs to be extracted from the resource"
+  default     = []
 }
 
 variable "all_log_types_enabled" {
-  default     = { enabled : false, retention_period : 0 }
+  type        = bool
   description = "Allow or Disallow all log types to be extracted from the resource"
-  type = object({
-    enabled : bool,
-    retention_period : number
-  })
+  default     = false
 }
 
 variable "all_metrics_enabled" {
-  default     = { enabled : false, retention_period : 0 }
+  type        = bool
   description = "Allow or Disallow all metrics to be extracted from the resource"
-  type = object({
-    enabled : bool,
-    retention_period : number
-  })
+  default     = false
 }
 
 variable "log_analytics_destination_type" {
-  default     = null
-  description = "Destination type for Log Analytics Workspace"
   type        = string
+  description = "Possible values are AzureDiagnostics and Dedicated. When set to Dedicated, logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table."
+  default     = null
 }

--- a/modules/azurerm/Resource-Monitoring-Diagnostic-Setting/versions.tf
+++ b/modules/azurerm/Resource-Monitoring-Diagnostic-Setting/versions.tf
@@ -1,11 +1,20 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained
-# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-# You may not alter or remove any copyright or other notice from copies of this content.
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # --------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Purpose
$subject

Diagnostic Settings Storage Retention feature is being [deprecated](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/migrate-to-azure-storage-lifecycle-policy?tabs=portal).

Therefore removing retention from our azurerm Resource-Monitoring-Diagnostic-Setting terraform modules.
