### PR TITLE
Output AKS Internal LB Subnet Name

### DIFF
--- a/modules/azurerm/AKS-Firewall/outputs.tf
+++ b/modules/azurerm/AKS-Firewall/outputs.tf
@@ -54,6 +54,11 @@ output "aks_internal_lb_subnet_id" {
   value      = azurerm_subnet.internal_load_balancer_subnet.id
 }
 
+output "aks_internal_lb_subnet_name" {
+  depends_on = [azurerm_subnet.internal_load_balancer_subnet]
+  value      = azurerm_subnet.internal_load_balancer_subnet.name
+}
+
 output "nodepool_network_security_group_id" {
   depends_on = [azurerm_network_security_group.aks_node_pool_subnet_nsg]
   value      = azurerm_network_security_group.aks_node_pool_subnet_nsg.id


### PR DESCRIPTION
## Purpose

Update the AKS module to output the internal load-balancer subnet's name.
