### PR TITLE
[main] Add Application Gateway SSL profile to ignore block

### DIFF
--- a/modules/azurerm/Application-Gateway/application_gateway.tf
+++ b/modules/azurerm/Application-Gateway/application_gateway.tf
@@ -268,7 +268,8 @@ resource "azurerm_application_gateway" "app_gateway" {
       tags,
       trusted_root_certificate,
       identity,
-      trusted_client_certificate
+      trusted_client_certificate,
+      ssl_profile
     ]
   }
 }


### PR DESCRIPTION
### Description
This adds the application gateway SSL profile to the ignore block as it is not required to update the mTLS related SSL profile as we have configured it to adhere to FAPI requirements.

### Related Issue
- https://github.com/wso2-enterprise/asgardeo-product/issues/24199

### Related PRs
- https://github.com/wso2/azure-terraform-modules/pull/74