### PR TITLE
[main] Add name abbreviation to AMPLS

### DIFF
--- a/modules/azurerm/Azure-Monitor-Private-Link-Scope-Service/azure_monitor_private_link_scope_service.tf
+++ b/modules/azurerm/Azure-Monitor-Private-Link-Scope-Service/azure_monitor_private_link_scope_service.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_monitor_private_link_scoped_service" "monitor_private_link_scoped_service" {
-  name                = join("-", ["amplss", var.monitor_private_link_scoped_service_name])
+  name                = join("-", [var.monitor_private_link_scoped_service_abbreviation, var.monitor_private_link_scoped_service_name])
   resource_group_name = var.resource_group_name
   scope_name          = var.private_link_scope_name
   linked_resource_id  = var.linked_resource_id

--- a/modules/azurerm/Azure-Monitor-Private-Link-Scope-Service/variables.tf
+++ b/modules/azurerm/Azure-Monitor-Private-Link-Scope-Service/variables.tf
@@ -28,3 +28,9 @@ variable "linked_resource_id" {
   description = "The ID of the linked resource"
   type        = string
 }
+
+variable "monitor_private_link_scoped_service_abbreviation" {
+  description = "The abbreviation to be used."
+  type        = string
+  default     = "amplss"
+}

--- a/modules/azurerm/Azure-Monitor-Private-Link-Scope/azure_monitor_private_link_scope.tf
+++ b/modules/azurerm/Azure-Monitor-Private-Link-Scope/azure_monitor_private_link_scope.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_monitor_private_link_scope" "monitor_private_link_scope" {
-  name                = join("-", ["ampls", var.monitor_private_link_scope_name])
+  name                = join("-", [var.monitor_private_link_scope_abbreviation, var.monitor_private_link_scope_name])
   resource_group_name = var.resource_group_name
   tags                = var.tags
 }

--- a/modules/azurerm/Azure-Monitor-Private-Link-Scope/variables.tf
+++ b/modules/azurerm/Azure-Monitor-Private-Link-Scope/variables.tf
@@ -23,3 +23,9 @@ variable "tags" {
   description = "A mapping of tags which should be assigned to the Azure Monitor Private Link Scope"
   type        = map(string)
 }
+
+variable "monitor_private_link_scope_abbreviation" {
+  description = "The abbreviation to be used."
+  type        = string
+  default     = "ampls"
+}


### PR DESCRIPTION
## Purpose
This is to introduce resource name abbreviation to the following resources.
```
azurerm_monitor_private_link_scope
azurerm_monitor_private_link_scoped_service
```