### PR TITLE
Add support for multiple custom rule match_conditions

### DIFF
--- a/modules/azurerm/FrontDoor-WAF/frontdoor_waf.tf
+++ b/modules/azurerm/FrontDoor-WAF/frontdoor_waf.tf
@@ -33,7 +33,7 @@ resource "azurerm_frontdoor_firewall_policy" "front_door_waf_policy" {
       rate_limit_threshold           = custom_rule.value.rate_limit_threshold
 
       dynamic "match_condition" {
-        for_each = [custom_rule.value.match_condition]
+        for_each = custom_rule.value.match_condition
 
         content {
           match_variable     = match_condition.value.match_variable


### PR DESCRIPTION
## Purpose
Add support for multiple custom rule match_conditions

## Goals
We need to give support for the multiple match conditions with custom WAF rules.

## Release note
Existing users need to update the existing condition to the following. 

Existing
```
match_condition = {
            match_variable     = "Testing condition"
            match_values       = ["/test"]
            operator           = "contains"
            negation_condition = false
            transforms         = []
          }
```

New
```
match_condition = [{
            match_variable     = "Testing condition"
            match_values       = ["/test"]
            operator           = "contains"
            negation_condition = false
            transforms         = []
          }]
```