### PR TITLE
Add Workload Identity Federation Manual AzureRM Service Endpoint & Output User Assigned Identity Client ID

### DIFF
--- a/modules/azuredevops/Workload-Identity-Federation-Manual-ARM-Service-Endpoint/devops_serviceendpoint.tf
+++ b/modules/azuredevops/Workload-Identity-Federation-Manual-ARM-Service-Endpoint/devops_serviceendpoint.tf
@@ -28,6 +28,6 @@ resource "azuredevops_serviceendpoint_azurerm" "devops_serviceendpoint_azurerm" 
   service_endpoint_authentication_scheme = "WorkloadIdentityFederation"
 
   credentials {
-    serviceprincipalid  = var.service_principal_id
+    serviceprincipalid = var.service_principal_id
   }
 }

--- a/modules/azuredevops/Workload-Identity-Federation-Manual-ARM-Service-Endpoint/devops_serviceendpoint.tf
+++ b/modules/azuredevops/Workload-Identity-Federation-Manual-ARM-Service-Endpoint/devops_serviceendpoint.tf
@@ -1,0 +1,33 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azuredevops_serviceendpoint_azurerm" "devops_serviceendpoint_azurerm" {
+  project_id                             = var.project_id
+  service_endpoint_name                  = var.service_endpoint_name
+  azurerm_spn_tenantid                   = var.tenant_id
+  azurerm_subscription_id                = var.subscription_id
+  azurerm_subscription_name              = var.subscription_name
+  description                            = var.description
+  service_endpoint_authentication_scheme = "WorkloadIdentityFederation"
+
+  credentials {
+    serviceprincipalid  = var.service_principal_id
+  }
+}

--- a/modules/azuredevops/Workload-Identity-Federation-Manual-ARM-Service-Endpoint/outputs.tf
+++ b/modules/azuredevops/Workload-Identity-Federation-Manual-ARM-Service-Endpoint/outputs.tf
@@ -27,3 +27,13 @@ output "serviceendpoint_name" {
   depends_on = [azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm]
   value      = azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm.service_endpoint_name
 }
+
+output "workload_identity_federation_issuer" {
+  depends_on = [azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm]
+  value      = azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm.workload_identity_federation_issuer
+}
+
+output "workload_identity_federation_subject" {
+  depends_on = [azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm]
+  value      = azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm.workload_identity_federation_subject
+}

--- a/modules/azuredevops/Workload-Identity-Federation-Manual-ARM-Service-Endpoint/outputs.tf
+++ b/modules/azuredevops/Workload-Identity-Federation-Manual-ARM-Service-Endpoint/outputs.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "serviceendpoint_id" {
+  depends_on = [azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm]
+  value      = azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm.id
+}
+
+output "serviceendpoint_name" {
+  depends_on = [azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm]
+  value      = azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm.service_endpoint_name
+}

--- a/modules/azuredevops/Workload-Identity-Federation-Manual-ARM-Service-Endpoint/variables.tf
+++ b/modules/azuredevops/Workload-Identity-Federation-Manual-ARM-Service-Endpoint/variables.tf
@@ -1,0 +1,54 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "service_endpoint_name" {
+  description = "The name of the service endpoint."
+  type        = string
+}
+
+variable "project_id" {
+  description = "The ID of the project."
+  type        = string
+}
+
+variable "description" {
+  description = "The description of the service endpoint."
+  type        = string
+}
+
+variable "service_principal_id" {
+  description = "The service principal application Id."
+  type        = string
+}
+
+variable "tenant_id" {
+  description = "The Tenant ID if the service principal."
+  type        = string
+}
+
+variable "subscription_id" {
+  description = "The Subscription ID of the Azure targets."
+  type        = string
+}
+
+variable "subscription_name" {
+  description = "The Subscription Name of the targets."
+  type        = string
+}

--- a/modules/azuredevops/Workload-Identity-Federation-Manual-ARM-Service-Endpoint/versions.tf
+++ b/modules/azuredevops/Workload-Identity-Federation-Manual-ARM-Service-Endpoint/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azuredevops = {
+      source  = "microsoft/azuredevops"
+      version = ">=0.1.0"
+    }
+  }
+}

--- a/modules/azurerm/User-Assigned-Identity/outputs.tf
+++ b/modules/azurerm/User-Assigned-Identity/outputs.tf
@@ -18,3 +18,8 @@ output "azurerm_user_assigned_identity_principal_id" {
   depends_on = [azurerm_user_assigned_identity.user_assigned_identity]
   value      = azurerm_user_assigned_identity.user_assigned_identity.principal_id
 }
+
+output "azurerm_user_assigned_identity_client_id" {
+  depends_on = [azurerm_user_assigned_identity.user_assigned_identity]
+  value      = azurerm_user_assigned_identity.user_assigned_identity.client_id
+}


### PR DESCRIPTION
## Purpose

Add Terraform module to create Workload Identity Federation with manual approach. And also, update the User Assigned Identity module to output the Client ID.