### PR TITLE
Modify create mode variable into an optional variable in postgresql flexible server

### DIFF
--- a/modules/azurerm/Application-Gateway/application_gateway.tf
+++ b/modules/azurerm/Application-Gateway/application_gateway.tf
@@ -72,8 +72,8 @@ resource "azurerm_application_gateway" "app_gateway" {
       for_each = var.waf_disabled_rule_group_settings
 
       content {
-        rule_group_name = lookup(disabled_rule_group.value, "rule_group_name")
-        rules           = lookup(disabled_rule_group.value, "rules")
+        rule_group_name = disabled_rule_group.value["rule_group_name"]
+        rules           = disabled_rule_group.value["rules"]
       }
     }
 
@@ -81,9 +81,9 @@ resource "azurerm_application_gateway" "app_gateway" {
       for_each = var.waf_exclusion_settings
 
       content {
-        match_variable          = lookup(exclusion.value, "match_variable")
-        selector                = lookup(exclusion.value, "selector")
-        selector_match_operator = lookup(exclusion.value, "selector_match_operator")
+        match_variable          = exclusion.value["match_variable"]
+        selector                = exclusion.value["selector"]
+        selector_match_operator = exclusion.value["selector_match_operator"]
       }
     }
   }
@@ -146,9 +146,9 @@ resource "azurerm_application_gateway" "app_gateway" {
     for_each = var.ssl_certificates_configs
 
     content {
-      name     = lookup(ssl_certificate.value, "name")
-      data     = filebase64(lookup(ssl_certificate.value, "data"))
-      password = lookup(ssl_certificate.value, "password")
+      name     = ssl_certificate.value["name"]
+      data     = filebase64(ssl_certificate.value["data"])
+      password = ssl_certificate.value["password"]
     }
   }
 
@@ -156,8 +156,8 @@ resource "azurerm_application_gateway" "app_gateway" {
     for_each = var.authentication_certificate_configs
 
     content {
-      name = lookup(authentication_certificate.value, "name")
-      data = filebase64(lookup(authentication_certificate.value, "data"))
+      name = authentication_certificate.value["name"]
+      data = filebase64(authentication_certificate.value["data"])
     }
   }
 
@@ -165,8 +165,8 @@ resource "azurerm_application_gateway" "app_gateway" {
     for_each = var.trusted_root_certificate_configs
 
     content {
-      name = lookup(trusted_root_certificate.value, "name")
-      data = filebase64(lookup(trusted_root_certificate.value, "data"))
+      name = trusted_root_certificate.value["name"]
+      data = filebase64(trusted_root_certificate.value["data"])
     }
   }
 
@@ -225,18 +225,18 @@ resource "azurerm_application_gateway" "app_gateway" {
     for_each = var.appgw_url_path_map
 
     content {
-      name                               = lookup(url_path_map.value, "name")
-      default_backend_address_pool_name  = lookup(url_path_map.value, "default_backend_address_pool_name")
-      default_backend_http_settings_name = lookup(url_path_map.value, "default_backend_http_settings_name", lookup(url_path_map.value, "default_backend_address_pool_name"))
+      name                               = url_path_map.value["name"]
+      default_backend_address_pool_name  = url_path_map.value["default_backend_address_pool_name"]
+      default_backend_http_settings_name = lookup(url_path_map.value, "default_backend_http_settings_name", url_path_map.value["default_backend_address_pool_name"])
 
       dynamic "path_rule" {
-        for_each = lookup(url_path_map.value, "path_rule")
+        for_each = url_path_map.value["path_rule"]
 
         content {
-          name                       = lookup(path_rule.value, "path_rule_name")
-          backend_address_pool_name  = lookup(path_rule.value, "backend_address_pool_name", lookup(path_rule.value, "path_rule_name"))
-          backend_http_settings_name = lookup(path_rule.value, "backend_http_settings_name", lookup(path_rule.value, "path_rule_name"))
-          paths                      = [lookup(path_rule.value, "paths")]
+          name                       = path_rule.value["path_rule_name"]
+          backend_address_pool_name  = lookup(path_rule.value, "backend_address_pool_name", path_rule.value["path_rule_name"])
+          backend_http_settings_name = lookup(path_rule.value, "backend_http_settings_name", path_rule.value["path_rule_name"])
+          paths                      = [path_rule.value["paths"]]
         }
       }
     }
@@ -246,9 +246,9 @@ resource "azurerm_application_gateway" "app_gateway" {
     for_each = var.appgw_redirect_configuration
 
     content {
-      name                 = lookup(redirect_configuration.value, "name")
+      name                 = redirect_configuration.value["name"]
       redirect_type        = lookup(redirect_configuration.value, "redirect_type", "Permanent")
-      target_listener_name = lookup(redirect_configuration.value, "target_listener_name")
+      target_listener_name = redirect_configuration.value["target_listener_name"]
       include_path         = lookup(redirect_configuration.value, "include_path", "true")
       include_query_string = lookup(redirect_configuration.value, "include_query_string", "true")
     }

--- a/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
@@ -27,7 +27,7 @@ resource "azurerm_postgresql_flexible_server" "postgresql_flexible_server" {
   source_server_id             = var.source_server_id
   tags                         = var.tags
 
-  dynamic high_availability {
+  dynamic "high_availability" {
     for_each = var.high_availability
     content {
       mode = high_availability.value.mode

--- a/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
@@ -30,7 +30,7 @@ resource "azurerm_postgresql_flexible_server" "postgresql_flexible_server" {
   dynamic "high_availability" {
     for_each = var.high_availability == null ? {} : var.high_availability
     content {
-      mode = high_availability.value.mode
+      mode = var.high_availability.mode
     }
   }
 

--- a/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
@@ -27,8 +27,11 @@ resource "azurerm_postgresql_flexible_server" "postgresql_flexible_server" {
   source_server_id             = var.source_server_id
   tags                         = var.tags
 
-  high_availability {
-    mode = "ZoneRedundant"
+  dynamic high_availability {
+    for_each = var.high_availability
+    content {
+      mode = high_availability.value.mode
+    }
   }
 
   maintenance_window {

--- a/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
@@ -30,7 +30,7 @@ resource "azurerm_postgresql_flexible_server" "postgresql_flexible_server" {
   dynamic "high_availability" {
     for_each = var.high_availability == null ? {} : var.high_availability
     content {
-      mode = var.high_availability.mode
+      mode                      = var.high_availability.mode
       standby_availability_zone = var.high_availability.standby_availability_zone
     }
   }

--- a/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
@@ -31,6 +31,7 @@ resource "azurerm_postgresql_flexible_server" "postgresql_flexible_server" {
     for_each = var.high_availability == null ? {} : var.high_availability
     content {
       mode = var.high_availability.mode
+      standby_availability_zone = var.high_availability.standby_availability_zone
     }
   }
 

--- a/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
@@ -28,7 +28,7 @@ resource "azurerm_postgresql_flexible_server" "postgresql_flexible_server" {
   tags                         = var.tags
 
   dynamic "high_availability" {
-    for_each = var.high_availability
+    for_each = var.high_availability == null ? {} : var.high_availability
     content {
       mode = high_availability.value.mode
     }

--- a/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
@@ -120,9 +120,11 @@ variable "source_server_id" {
 }
 
 variable "high_availability" {
-  default     = {}
+  default = {
+    mode = null
+  }
   description = "The high availability mode for the PostgreSQL Flexible Server. Possible value are SameZone or ZoneRedundant"
   type = object({
-    mode = optional(string, null)
+    mode = string
   })
 }

--- a/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
@@ -123,7 +123,7 @@ variable "high_availability" {
   default     = null
   description = "The high availability mode for the PostgreSQL Flexible Server. Possible value are SameZone or ZoneRedundant"
   type = object({
-    mode = string
+    mode                      = string
     standby_availability_zone = any
   })
 }

--- a/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
@@ -120,6 +120,7 @@ variable "source_server_id" {
 }
 
 variable "high_availability" {
+  default     = null
   description = "The high availability mode for the PostgreSQL Flexible Server. Possible value are SameZone or ZoneRedundant"
   type = object({
     mode = string

--- a/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
@@ -108,8 +108,8 @@ variable "maintainance_start_minute" {
 }
 
 variable "create_mode" {
-  default     = "Default"
-  description = "Create mode for the PostgreSQL Server. Possible values are Default, PointInTimeRestore, Replica and Update"
+  default     = null
+  description = "Optional parameter. The creation mode which can be used to restore or replicate existing servers. Possible values are Default, GeoRestore, PointInTimeRestore, Replica and Update. Changing this forces a new PostgreSQL Flexible Server to be created"
   type        = string
 }
 

--- a/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
@@ -118,3 +118,11 @@ variable "source_server_id" {
   description = "Optional Parameter to create a server as a replica of an existing server"
   type        = string
 }
+
+variable "high_availability" {
+  default = null
+  description = "The high availability mode for the PostgreSQL Flexible Server. Possible value are SameZone or ZoneRedundant"
+  type = object({
+    mode = string
+  })
+}

--- a/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
@@ -120,9 +120,9 @@ variable "source_server_id" {
 }
 
 variable "high_availability" {
-  default = null
+  default     = {}
   description = "The high availability mode for the PostgreSQL Flexible Server. Possible value are SameZone or ZoneRedundant"
   type = object({
-    mode = string
+    mode = optional(string, null)
   })
 }

--- a/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
@@ -108,7 +108,7 @@ variable "maintainance_start_minute" {
 }
 
 variable "create_mode" {
-  default     = null
+  default     = "Default"
   description = "The creation mode which can be used to restore or replicate existing servers. Possible values are Default, GeoRestore, PointInTimeRestore, Replica and Update. Changing this forces a new PostgreSQL Flexible Server to be created"
   type        = string
 }
@@ -124,5 +124,6 @@ variable "high_availability" {
   description = "The high availability mode for the PostgreSQL Flexible Server. Possible value are SameZone or ZoneRedundant"
   type = object({
     mode = string
+    standby_availability_zone = any
   })
 }

--- a/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
@@ -120,9 +120,6 @@ variable "source_server_id" {
 }
 
 variable "high_availability" {
-  default = {
-    mode = null
-  }
   description = "The high availability mode for the PostgreSQL Flexible Server. Possible value are SameZone or ZoneRedundant"
   type = object({
     mode = string

--- a/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
@@ -109,7 +109,7 @@ variable "maintainance_start_minute" {
 
 variable "create_mode" {
   default     = null
-  description = "Optional parameter. The creation mode which can be used to restore or replicate existing servers. Possible values are Default, GeoRestore, PointInTimeRestore, Replica and Update. Changing this forces a new PostgreSQL Flexible Server to be created"
+  description = "The creation mode which can be used to restore or replicate existing servers. Possible values are Default, GeoRestore, PointInTimeRestore, Replica and Update. Changing this forces a new PostgreSQL Flexible Server to be created"
   type        = string
 }
 


### PR DESCRIPTION
## Purpose
As per the new version of the azure terraform modules every postgre sql server that will be created will get created with the high availability option. Therefore changed the high availability block into a dynamic block.

From wso2/azure-terraform-modules/v0.11.0. -> v0.25.0 postgre sql server high availability is added by default. With this change, high availability will be optional.
