### PR TITLE
Remove standby availability zone variable from high availability optional block in postgre sql server module

### DIFF
--- a/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
@@ -28,7 +28,7 @@ resource "azurerm_postgresql_flexible_server" "postgresql_flexible_server" {
   tags                         = var.tags
 
   dynamic "high_availability" {
-    for_each = var.high_availability == null ? {} : var.high_availability
+    for_each = var.high_availability.mode == null ? {} : var.high_availability
     content {
       mode                      = var.high_availability.mode
       standby_availability_zone = var.high_availability.standby_availability_zone

--- a/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
@@ -30,8 +30,7 @@ resource "azurerm_postgresql_flexible_server" "postgresql_flexible_server" {
   dynamic "high_availability" {
     for_each = var.high_availability == null ? {} : var.high_availability
     content {
-      mode                      = var.high_availability.mode
-      standby_availability_zone = var.high_availability.standby_availability_zone
+      mode = var.high_availability.mode
     }
   }
 

--- a/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
@@ -28,7 +28,7 @@ resource "azurerm_postgresql_flexible_server" "postgresql_flexible_server" {
   tags                         = var.tags
 
   dynamic "high_availability" {
-    for_each = var.high_availability.mode == null ? {} : var.high_availability
+    for_each = var.high_availability == null ? {} : var.high_availability
     content {
       mode                      = var.high_availability.mode
       standby_availability_zone = var.high_availability.standby_availability_zone

--- a/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
@@ -123,7 +123,6 @@ variable "high_availability" {
   default     = null
   description = "The high availability mode for the PostgreSQL Flexible Server. Possible value are SameZone or ZoneRedundant"
   type = object({
-    mode                      = string
-    standby_availability_zone = number
+    mode = string
   })
 }

--- a/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
@@ -124,6 +124,6 @@ variable "high_availability" {
   description = "The high availability mode for the PostgreSQL Flexible Server. Possible value are SameZone or ZoneRedundant"
   type = object({
     mode                      = string
-    standby_availability_zone = any
+    standby_availability_zone = number
   })
 }


### PR DESCRIPTION
## Purpose
High availability block of azurerm postgresql_flexible_server module does not support more than standby availability zone variable. Hence removing it from the module, to enable high availability option to postgresql flexible server.

## Related PRs
https://github.com/wso2/azure-terraform-modules/pull/85