### PR TITLE
Change postgre sql server high availability standby availability zone variable to number

### DIFF
--- a/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/variables.tf
@@ -128,5 +128,5 @@ variable "high_availability_mode" {
 variable "high_availability_standby_availability_zone" {
   default     = null
   description = "Specifies the Availability Zone in which the standby Flexible Server should be located."
-  type        = any
+  type        = number
 }


### PR DESCRIPTION
## Purpose
To change the variable type of the high availability block standby availability zone variable type to number, to match the azurerm documentation