### PR TITLE
Add HTTPS & FTPS Configurations for Function Apps

### DIFF
--- a/modules/azurerm/Function-App-Managed-Identity/function_app_managed_identity.tf
+++ b/modules/azurerm/Function-App-Managed-Identity/function_app_managed_identity.tf
@@ -20,6 +20,7 @@ resource "azurerm_function_app" "function_app_with_managed_identity" {
   app_settings               = var.app_settings
   version                    = var.app_runtime_version
   client_cert_mode           = var.client_cert_mode
+  https_only                 = var.https_only
   tags                       = var.tags
 
   site_config {

--- a/modules/azurerm/Function-App-Managed-Identity/variables.tf
+++ b/modules/azurerm/Function-App-Managed-Identity/variables.tf
@@ -104,3 +104,9 @@ variable "tags" {
   description = "Default tag list"
   type        = map(string)
 }
+
+variable "https_only" {
+  default     = true
+  description = "Should the Function App only be accessible over HTTPS? Defaults to true."
+  type        = bool
+}

--- a/modules/azurerm/Function-App-Managed-Identity/variables.tf
+++ b/modules/azurerm/Function-App-Managed-Identity/variables.tf
@@ -95,7 +95,7 @@ variable "health_check_path" {
 }
 
 variable "ftps_state" {
-  default     = "AllAllowed"
+  default     = "FtpsOnly"
   description = "State of FTP / FTPS service for this function app. Possible values include: AllAllowed, FtpsOnly and Disabled. Defaults to AllAllowed."
   type        = string
 }


### PR DESCRIPTION
## Purpose

Support configuring HTTPS and FTPS configurations for the Function Apps. 
With this PR, the HTTPS is enforced in the Function App and the FTP protocol is changed to the FTPS.