### PR TITLE
Allow disabling ip masking for client IPs in Application Insights

### DIFF
--- a/modules/azurerm/Application-Insights/application_insights.tf
+++ b/modules/azurerm/Application-Insights/application_insights.tf
@@ -19,5 +19,6 @@ resource "azurerm_application_insights" "application_insights" {
   retention_in_days                     = var.retention_in_days
   disable_ip_masking                    = var.disable_ip_masking
   workspace_id                          = var.workspace_id
+  disable_ip_masking                   = var.disable_ip_masking
   tags                                  = var.tags
 }

--- a/modules/azurerm/Application-Insights/variables.tf
+++ b/modules/azurerm/Application-Insights/variables.tf
@@ -67,3 +67,9 @@ variable "workspace_id" {
   type        = string
   default     = null
 }
+
+variable "disable_ip_masking" {
+  description = "Disable masking and log the real client IP"
+  type      = bool
+  default = false
+}

--- a/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/variables.tf
+++ b/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/variables.tf
@@ -28,13 +28,13 @@ variable "alert_enabled" {
 variable "activity_log_administrative_alerts" {
   description = "Map of azure activity log administrative alerts"
   type = map(object({
-    scopes                  = list(string)
-    reason                  = string
-    description             = string
-    monitor_action_group_id = string
-    category                = string
-    operation_name          = string
-    resource_id             = string
+    scopes                          = list(string)
+    monitor_activity_log_alert_name = string
+    description                     = string
+    monitor_action_group_id         = string
+    category                        = string
+    operation_name                  = string
+    resource_id                     = string
   }))
 }
 


### PR DESCRIPTION
## Purpose
> In Azure Application Insights, by default the real client IP is masked as 0.0.0.0 in the logs. Use this argument to disable masking and log the real client IP. Defaults to false.
