### PR TITLE
Add `queue_status` Configuration to Azure DevOps Build Definition Modules

### DIFF
--- a/modules/azuredevops/GitHub-Build-Definition-Pull-Request-Trigger/github_build_definition_pull_request_trigger.tf
+++ b/modules/azuredevops/GitHub-Build-Definition-Pull-Request-Trigger/github_build_definition_pull_request_trigger.tf
@@ -14,6 +14,7 @@ resource "azuredevops_build_definition" "devops_build_definition" {
   name            = var.build_definition_name
   path            = var.pipeline_path
   agent_pool_name = var.agent_pool_name
+  queue_status    = var.status
 
   ci_trigger {
     use_yaml = true

--- a/modules/azuredevops/GitHub-Build-Definition-Pull-Request-Trigger/variables.tf
+++ b/modules/azuredevops/GitHub-Build-Definition-Pull-Request-Trigger/variables.tf
@@ -85,3 +85,9 @@ variable "repo_type" {
   description = "The type of the repository."
   type        = string
 }
+
+variable "status" {
+  default     = "enabled"
+  description = "The queue status of the build definition. Valid values: enabled or paused or disabled"
+  type        = string
+}

--- a/modules/azuredevops/GitHub-Build-Definition/github_build_definition.tf
+++ b/modules/azuredevops/GitHub-Build-Definition/github_build_definition.tf
@@ -14,6 +14,7 @@ resource "azuredevops_build_definition" "devops_build_definition" {
   name            = var.build_definition_name
   agent_pool_name = var.agent_pool_name
   path            = var.pipeline_path
+  queue_status    = var.status
 
   ci_trigger {
     use_yaml = true

--- a/modules/azuredevops/GitHub-Build-Definition/variables.tf
+++ b/modules/azuredevops/GitHub-Build-Definition/variables.tf
@@ -61,3 +61,9 @@ variable "repo_type" {
   description = "The type of the repository."
   type        = string
 }
+
+variable "status" {
+  default     = "enabled"
+  description = "The queue status of the build definition. Valid values: enabled or paused or disabled"
+  type        = string
+}


### PR DESCRIPTION
## Purpose

Add support to configure status of the Azure DevOps build definitions.

- https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition#queue_status