### PR TITLE
Allow to set alert emails for mssql server vulnerability assessment

### DIFF
--- a/modules/azurerm/MsSQL-Server-Vulnerability-Assessment/mssql_server_vulnerability_assessment.tf
+++ b/modules/azurerm/MsSQL-Server-Vulnerability-Assessment/mssql_server_vulnerability_assessment.tf
@@ -13,6 +13,7 @@ resource "azurerm_mssql_server_security_alert_policy" "mssql_server_security_ale
   resource_group_name = var.resource_group_name
   server_name         = var.server_name
   state               = "Enabled"
+  email_addresses     = var.alert_emails
 }
 
 resource "azurerm_mssql_server_vulnerability_assessment" "mssql_server_vulnerability_assessment" {

--- a/modules/azurerm/MsSQL-Server-Vulnerability-Assessment/variables.tf
+++ b/modules/azurerm/MsSQL-Server-Vulnerability-Assessment/variables.tf
@@ -46,3 +46,9 @@ variable "recurring_scans_email_subscription_admins_enabled" {
   description = "Enable email subscription for admins"
   type        = bool
 }
+
+variable "alert_emails" {
+  default     = []
+  description = "Emails to send the alert"
+  type        = list(string)
+}


### PR DESCRIPTION
## Purpose
> With the Mssql Server vulnerability assessment we can send alerts for the following vulnerabilities: Sql_Injection, Sql_Injection_Vulnerability, Access_Anomaly, Data_Exfiltration, Unsafe_Action. In such case we can set a set of email addresses to send alerts. With this change we will be allowing to pass a set of emails that the alerts should be sent.
