### PR TITLE
Add variable to override storage_redundancy in azurerm_cosmosdb_account

### DIFF
--- a/modules/azurerm/Cosmos-Database-Account/cosmos_database_account.tf
+++ b/modules/azurerm/Cosmos-Database-Account/cosmos_database_account.tf
@@ -42,6 +42,7 @@ resource "azurerm_cosmosdb_account" "cosmos_db_account" {
     type                = var.backup_type
     interval_in_minutes = var.periodic_backup_interval
     retention_in_hours  = var.periodic_backup_retention_in_hours
+    storage_redundancy  = var.backup_storage_redundancy
   }
 
   dynamic "capabilities" {

--- a/modules/azurerm/Cosmos-Database-Account/variables.tf
+++ b/modules/azurerm/Cosmos-Database-Account/variables.tf
@@ -130,3 +130,9 @@ variable "periodic_backup_retention_in_hours" {
   description = "The periodic backup retention in hours for the Cosmos DB account."
   type        = number
 }
+
+variable "backup_storage_redundancy" {
+  default     = "Geo"
+  description = "The backup storage redundancy for the Cosmos DB account."
+  type        = string
+}


### PR DESCRIPTION
## Purpose
> Add variable to override storage_redundancy in azurerm_cosmosdb_account

## Changes
> This change will add an optional variable called `backup_storage_redundancy` and it will use the default as `Geo` 
- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account#storage_redundancy