### PR TITLE
Add support to analytics storage for cosmos db account

### DIFF
--- a/modules/azurerm/Cosmos-DB-SQL-Container/cosmos_db_sql_container.tf
+++ b/modules/azurerm/Cosmos-DB-SQL-Container/cosmos_db_sql_container.tf
@@ -10,14 +10,15 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_cosmosdb_sql_container" "cosmosdb_sql_container" {
-  name                  = var.container_name
-  resource_group_name   = var.resource_group_name
-  account_name          = var.cosmos_db_account_name
-  database_name         = var.cosmos_db_name
-  partition_key_path    = var.partition_key_path
-  partition_key_version = var.partition_key_version
-  throughput            = var.autoscale_enabled == false ? var.throughput : null
-  default_ttl           = var.default_ttl
+  name                   = var.container_name
+  resource_group_name    = var.resource_group_name
+  account_name           = var.cosmos_db_account_name
+  database_name          = var.cosmos_db_name
+  partition_key_path     = var.partition_key_path
+  partition_key_version  = var.partition_key_version
+  throughput             = var.autoscale_enabled == false ? var.throughput : null
+  default_ttl            = var.default_ttl
+  analytical_storage_ttl = var.analytical_storage_ttl
 
   dynamic "autoscale_settings" {
     for_each = local.autoscale_setting

--- a/modules/azurerm/Cosmos-DB-SQL-Container/variables.tf
+++ b/modules/azurerm/Cosmos-DB-SQL-Container/variables.tf
@@ -63,3 +63,9 @@ variable "default_ttl" {
   description = "The default time to live of SQL container."
   type        = number
 }
+
+variable "analytical_storage_ttl" {
+  default     = null
+  description = "The default time to live of Analytical Storage for this SQL container"
+  type        = number
+}

--- a/modules/azurerm/Cosmos-Database-Account/cosmos_database_account.tf
+++ b/modules/azurerm/Cosmos-Database-Account/cosmos_database_account.tf
@@ -21,6 +21,7 @@ resource "azurerm_cosmosdb_account" "cosmos_db_account" {
   enable_multiple_write_locations   = var.enable_multiple_write_locations
   enable_automatic_failover         = length(local.geo_locations) == 1 ? false : var.enable_automatic_failover
   is_virtual_network_filter_enabled = var.is_virtual_network_filter_enabled
+  analytical_storage_enabled        = var.analytical_storage_enabled
 
   dynamic "geo_location" {
     for_each = local.geo_locations

--- a/modules/azurerm/Cosmos-Database-Account/cosmos_database_account.tf
+++ b/modules/azurerm/Cosmos-Database-Account/cosmos_database_account.tf
@@ -18,6 +18,7 @@ resource "azurerm_cosmosdb_account" "cosmos_db_account" {
   tags                              = var.tags
   enable_free_tier                  = var.enable_free_tier
   public_network_access_enabled     = var.public_network_access_enabled
+  ip_range_filter                   = var.ip_range_filter
   enable_multiple_write_locations   = var.enable_multiple_write_locations
   enable_automatic_failover         = length(local.geo_locations) == 1 ? false : var.enable_automatic_failover
   is_virtual_network_filter_enabled = var.is_virtual_network_filter_enabled

--- a/modules/azurerm/Cosmos-Database-Account/variables.tf
+++ b/modules/azurerm/Cosmos-Database-Account/variables.tf
@@ -136,3 +136,9 @@ variable "backup_storage_redundancy" {
   description = "The backup storage redundancy for the Cosmos DB account."
   type        = string
 }
+
+variable "analytical_storage_enabled" {
+  default     = false
+  description = "Enable Analytical Storage option for the Cosmos DB account"
+  type        = bool
+}

--- a/modules/azurerm/Cosmos-Database-Account/variables.tf
+++ b/modules/azurerm/Cosmos-Database-Account/variables.tf
@@ -142,3 +142,9 @@ variable "analytical_storage_enabled" {
   description = "Enable Analytical Storage option for the Cosmos DB account"
   type        = bool
 }
+
+variable "ip_range_filter" {
+  default     = null
+  description = "A set of IP addresses or IP address ranges in CIDR form to be included as the allowed list of client IPs"
+  type        = string
+}


### PR DESCRIPTION
## Purpose
- Add support to selective enable analytics storage for azure cosmos db account
- Add analytics storage ttl for cosmos db sql container
- Allow to pass Client IP list for Cosmos DB network rules
