### PR TITLE
[main] Add Alert Processing Rule to Suppress Resolved Alerts

### DIFF
--- a/modules/azurerm/Monitor-Alert-Processing-Rule-Suppression-Resolved/monitor_alert_processing_rule_suppression.tf
+++ b/modules/azurerm/Monitor-Alert-Processing-Rule-Suppression-Resolved/monitor_alert_processing_rule_suppression.tf
@@ -1,0 +1,26 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_monitor_alert_processing_rule_suppression" "monitor_alert_processing_rule_suppression" {
+  name                = join("-", ["apr", var.monitor_alert_processing_rule_suppression_name])
+  resource_group_name = var.resource_group_name
+  description         = var.description
+  scopes              = var.scopes
+  enabled             = var.enabled
+  tags                = var.tags
+
+  condition {
+    monitor_condition {
+      operator = var.operator
+      values   = var.values
+    }
+  }
+}

--- a/modules/azurerm/Monitor-Alert-Processing-Rule-Suppression-Resolved/variables.tf
+++ b/modules/azurerm/Monitor-Alert-Processing-Rule-Suppression-Resolved/variables.tf
@@ -1,0 +1,53 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+variable "resource_group_name" {
+  description = "Name of the Resource Group"
+  type        = string
+}
+
+variable "monitor_alert_processing_rule_suppression_name" {
+  description = "Name of the Monitor Alert Processing Rule Suppression"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags for the Resource"
+  type        = map(string)
+}
+
+variable "scopes" {
+  description = "The scopes to apply the suppression to"
+  type        = list(string)
+}
+
+variable "description" {
+  description = "Description of the Monitor Alert Processing Rule Suppression"
+  type        = string
+}
+
+variable "enabled" {
+  description = "Is the Monitor Alert Processing Rule Suppression Enabled?"
+  type        = bool
+  default     = true
+}
+
+variable "operator" {
+  description = "Operator for the Monitor Alert Processing Rule Suppression"
+  type        = string
+  default     = "Equals"
+}
+
+variable "values" {
+  description = "Values for the Monitor Alert Processing Rule Suppression"
+  type        = list(string)
+  default     = ["Resolved"]
+}

--- a/modules/azurerm/Monitor-Alert-Processing-Rule-Suppression-Resolved/versions.tf
+++ b/modules/azurerm/Monitor-Alert-Processing-Rule-Suppression-Resolved/versions.tf
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.52.0"
+    }
+  }
+}


### PR DESCRIPTION
## Description 

Onboard Alert Processing Rule module to suppress any Azure Resolved Alerts. This will be applied always, as there is no `schedule` configuration and this module only supports conditions related to `monitor_condition`.