### PR TITLE
Add DNS TXT Record Terraform Module

### DIFF
--- a/modules/azurerm/DNS-TXT-Record/dns_txt_record.tf
+++ b/modules/azurerm/DNS-TXT-Record/dns_txt_record.tf
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_dns_txt_record" "dns_txt_record" {
+  name                = var.name
+  zone_name           = var.dns_zone_name
+  resource_group_name = var.resource_group_name
+  ttl                 = var.ttl
+  tags                = var.tags
+
+  record {
+    value = var.txt_record
+  }
+}

--- a/modules/azurerm/DNS-TXT-Record/outputs.tf
+++ b/modules/azurerm/DNS-TXT-Record/outputs.tf
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "dns_txt_record_id" {
+  description = "The ID of the DNS TXT Record."
+  depends_on  = [azurerm_dns_txt_record.dns_txt_record]
+  value       = azurerm_dns_txt_record.dns_txt_record.id
+}
+
+output "dns_txt_record_fqdn" {
+  description = "The FQDN of the DNS TXT Record."
+  depends_on  = [azurerm_dns_txt_record.dns_txt_record]
+  value       = azurerm_dns_txt_record.dns_txt_record.fqdn
+}

--- a/modules/azurerm/DNS-TXT-Record/variables.tf
+++ b/modules/azurerm/DNS-TXT-Record/variables.tf
@@ -1,0 +1,50 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "name" {
+  description = "The name of the TXT record."
+  type        = string
+}
+
+variable "dns_zone_name" {
+  description = "The name of the DNS zone in which the record should be created."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group in which the DNS zone exists."
+  type        = string
+}
+
+variable "ttl" {
+  description = "The Time To Live (TTL) of the DNS record in seconds."
+  default     = 3600
+  type        = number
+}
+
+variable "txt_record" {
+  description = "The value of the TXT record."
+  type        = string
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to the resource."
+  type        = map(string)
+}

--- a/modules/azurerm/DNS-TXT-Record/versions.tf
+++ b/modules/azurerm/DNS-TXT-Record/versions.tf
@@ -1,0 +1,30 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.52.0"
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

Introduce a terraform module to configure DNS TXT records in Azure. This is an encapsulated module of [dns_txt_records](https://registry.terraform.io/providers/hashicorp/azurerm/3.52.0/docs/resources/dns_txt_record).