### PR TITLE
Add CDN FrontDoor Terraform Modules

### DIFF
--- a/.github/workflows/tffmt.yml
+++ b/.github/workflows/tffmt.yml
@@ -1,8 +1,9 @@
+---
 name: TF Formatting Check
 on:
   pull_request:
     branches: 
-        - main
+      - main
 
 jobs:
   build:

--- a/.github/workflows/tflinter.yml
+++ b/.github/workflows/tflinter.yml
@@ -1,3 +1,4 @@
+---
 name: TF Linter Check
 on:
   pull_request:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,3 +1,4 @@
+---
 name: Trivy Scan
 on:
   pull_request:

--- a/modules/azurerm/AKS-Firewall/aks_cluster.tf
+++ b/modules/azurerm/AKS-Firewall/aks_cluster.tf
@@ -15,7 +15,7 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
   resource_group_name                 = var.resource_group_name
   dns_prefix                          = join("-", ["aks", var.aks_cluster_dns_prefix])
   kubernetes_version                  = var.kubernetes_version
-  api_server_authorized_ip_ranges     = try(var.api_server_authorized_ip_ranges, null)
+  api_server_authorized_ip_ranges     = var.api_server_authorized_ip_ranges
   node_resource_group                 = join("-", ["rg", var.aks_node_pool_resource_group_name])
   sku_tier                            = var.sku_tier
   private_cluster_enabled             = var.private_cluster_enabled

--- a/modules/azurerm/AKS-Generic/aks_cluster.tf
+++ b/modules/azurerm/AKS-Generic/aks_cluster.tf
@@ -15,6 +15,7 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
   resource_group_name                 = var.aks_resource_group_name
   dns_prefix                          = join("-", ["aks", var.aks_cluster_dns_prefix])
   kubernetes_version                  = var.kubernetes_version
+  api_server_authorized_ip_ranges     = var.api_server_authorized_ip_ranges
   node_resource_group                 = join("-", ["rg", var.aks_node_pool_resource_group_name])
   sku_tier                            = var.sku_tier
   private_cluster_enabled             = var.private_cluster_enabled

--- a/modules/azurerm/AKS-Generic/variables.tf
+++ b/modules/azurerm/AKS-Generic/variables.tf
@@ -307,3 +307,8 @@ variable "internal_load_balancer_subnet_enforce_private_link_endpoint_network_po
   description = "Enable or Disable network policies for the private link endpoint on the internal load balancer subnet"
   type        = bool
 }
+
+variable "api_server_authorized_ip_ranges" {
+  description = "List of authorized IP ranges for the Kubernetes API server"
+  type        = list(string)
+}

--- a/modules/azurerm/Bastion-Host/variables.tf
+++ b/modules/azurerm/Bastion-Host/variables.tf
@@ -102,7 +102,7 @@ variable "public_ip_zones" {
 }
 
 variable "allow_https_internet_inbound" {
-  default     = true
+  default     = false
   description = "Specify whether to allow HTTPS Inbound internet traffic or not"
   type        = bool
 }

--- a/modules/azurerm/CDN-FrontDoor-Custom-Domain-Association/cdn_frontdoor_custom_domain_association.tf
+++ b/modules/azurerm/CDN-FrontDoor-Custom-Domain-Association/cdn_frontdoor_custom_domain_association.tf
@@ -1,0 +1,24 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_cdn_frontdoor_custom_domain_association" "cdn_frontdoor_custom_domain_association" {
+  cdn_frontdoor_custom_domain_id = var.cdn_frontdoor_custom_domain_id
+  cdn_frontdoor_route_ids        = var.cdn_frontdoor_route_ids
+}

--- a/modules/azurerm/CDN-FrontDoor-Custom-Domain-Association/outputs.tf
+++ b/modules/azurerm/CDN-FrontDoor-Custom-Domain-Association/outputs.tf
@@ -1,0 +1,24 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "id" {
+  depends_on = [azurerm_cdn_frontdoor_custom_domain_association.cdn_frontdoor_custom_domain_association]
+  value      = azurerm_cdn_frontdoor_custom_domain_association.cdn_frontdoor_custom_domain_association.id
+}

--- a/modules/azurerm/CDN-FrontDoor-Custom-Domain-Association/variables.tf
+++ b/modules/azurerm/CDN-FrontDoor-Custom-Domain-Association/variables.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "cdn_frontdoor_custom_domain_id" {
+  description = "The ID of the CDN Front Door Custom Domain."
+  type        = string
+}
+
+variable "cdn_frontdoor_route_ids" {
+  description = "The IDs of the CDN Front Door Routes."
+  type        = list(string)
+}

--- a/modules/azurerm/CDN-FrontDoor-Custom-Domain-Association/versions.tf
+++ b/modules/azurerm/CDN-FrontDoor-Custom-Domain-Association/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.52.0"
+    }
+  }
+}

--- a/modules/azurerm/CDN-FrontDoor-Custom-Domain/cdn_frontdoor_custom_domain.tf
+++ b/modules/azurerm/CDN-FrontDoor-Custom-Domain/cdn_frontdoor_custom_domain.tf
@@ -1,0 +1,32 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_cdn_frontdoor_custom_domain" "cdn_frontdoor_custom_domain" {
+  name                     = join("-", [var.custom_domain_name, var.custom_domain_suffix])
+  cdn_frontdoor_profile_id = var.cdn_frontdoor_profile_id
+  dns_zone_id              = var.dns_zone_id
+  host_name                = var.host_name
+
+  tls {
+    certificate_type        = var.certificate_type
+    minimum_tls_version     = var.minimum_tls_version
+    cdn_frontdoor_secret_id = var.certificate_type == "CustomerCertificate" ? var.cdn_frontdoor_secret_id : null
+  }
+}

--- a/modules/azurerm/CDN-FrontDoor-Custom-Domain/outputs.tf
+++ b/modules/azurerm/CDN-FrontDoor-Custom-Domain/outputs.tf
@@ -1,0 +1,34 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "id" {
+  depends_on = [azurerm_cdn_frontdoor_custom_domain.cdn_frontdoor_custom_domain]
+  value      = azurerm_cdn_frontdoor_custom_domain.cdn_frontdoor_custom_domain.id
+}
+
+output "expiration_date" {
+  depends_on = [azurerm_cdn_frontdoor_custom_domain.cdn_frontdoor_custom_domain]
+  value      = azurerm_cdn_frontdoor_custom_domain.cdn_frontdoor_custom_domain.expiration_date
+}
+
+output "validation_token" {
+  depends_on = [azurerm_cdn_frontdoor_custom_domain.cdn_frontdoor_custom_domain]
+  value      = azurerm_cdn_frontdoor_custom_domain.cdn_frontdoor_custom_domain.validation_token
+}

--- a/modules/azurerm/CDN-FrontDoor-Custom-Domain/variables.tf
+++ b/modules/azurerm/CDN-FrontDoor-Custom-Domain/variables.tf
@@ -1,0 +1,61 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "custom_domain_name" {
+  description = "The custom domain name."
+  type        = string
+}
+
+variable "custom_domain_suffix" {
+  description = "The custom domain suffix."
+  type        = string
+  default     = "custom-domain"
+}
+
+variable "cdn_frontdoor_profile_id" {
+  description = "The ID of the CDN Front Door Profile."
+  type        = string
+}
+
+variable "dns_zone_id" {
+  description = "The ID of the DNS Zone."
+  type        = string
+}
+
+variable "host_name" {
+  description = "The host name of the custom domain."
+  type        = string
+}
+
+variable "certificate_type" {
+  description = "The type of the certificate."
+  type        = string
+}
+
+variable "minimum_tls_version" {
+  description = "The minimum TLS version."
+  type        = string
+  default     = "TLS12"
+}
+
+variable "cdn_frontdoor_secret_id" {
+  description = "The ID of the CDN Front Door Secret."
+  type        = string
+}

--- a/modules/azurerm/CDN-FrontDoor-Custom-Domain/versions.tf
+++ b/modules/azurerm/CDN-FrontDoor-Custom-Domain/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.52.0"
+    }
+  }
+}

--- a/modules/azurerm/CDN-FrontDoor-Endpoint/cdn_frontdoor_endpoint.tf
+++ b/modules/azurerm/CDN-FrontDoor-Endpoint/cdn_frontdoor_endpoint.tf
@@ -1,0 +1,26 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_cdn_frontdoor_endpoint" "cdn_frontdoor_endpoint" {
+  name                     = join("-", [var.frontdoor_endpoint_abbreviation, var.frontdoor_endpoint_name])
+  cdn_frontdoor_profile_id = var.cdn_frontdoor_profile_id
+  enabled                  = var.enabled
+  tags                     = var.tags
+}

--- a/modules/azurerm/CDN-FrontDoor-Endpoint/outputs.tf
+++ b/modules/azurerm/CDN-FrontDoor-Endpoint/outputs.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "id" {
+  depends_on = [azurerm_cdn_frontdoor_endpoint.cdn_frontdoor_endpoint]
+  value      = azurerm_cdn_frontdoor_endpoint.cdn_frontdoor_endpoint.id
+}
+
+output "host_name" {
+  depends_on = [azurerm_cdn_frontdoor_endpoint.cdn_frontdoor_endpoint]
+  value      = azurerm_cdn_frontdoor_endpoint.cdn_frontdoor_endpoint.host_name
+}

--- a/modules/azurerm/CDN-FrontDoor-Endpoint/variables.tf
+++ b/modules/azurerm/CDN-FrontDoor-Endpoint/variables.tf
@@ -1,0 +1,47 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "frontdoor_endpoint_abbreviation" {
+  description = "The abbreviation of the Front Door Endpoint."
+  type        = string
+  default     = "fe"
+}
+
+variable "frontdoor_endpoint_name" {
+  description = "The name of the Front Door Endpoint."
+  type        = string
+}
+
+variable "cdn_frontdoor_profile_id" {
+  description = "The ID of the CDN Front Door Profile."
+  type        = string
+}
+
+variable "enabled" {
+  description = "Is the CDN Front Door Endpoint enabled?"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to the resource."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/azurerm/CDN-FrontDoor-Endpoint/versions.tf
+++ b/modules/azurerm/CDN-FrontDoor-Endpoint/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.52.0"
+    }
+  }
+}

--- a/modules/azurerm/CDN-FrontDoor-Origin-Group/cdn_frontdoor_origin_group.tf
+++ b/modules/azurerm/CDN-FrontDoor-Origin-Group/cdn_frontdoor_origin_group.tf
@@ -1,0 +1,98 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_cdn_frontdoor_origin_group" "cdn_frontdoor_origin_group" {
+  name                     = join("-", [var.origin_group_name, var.origin_group_suffix])
+  cdn_frontdoor_profile_id = var.cdn_frontdoor_profile_id
+  session_affinity_enabled = var.enable_session_affinity
+
+  restore_traffic_time_to_healed_or_new_endpoint_in_minutes = var.time_to_restore_traffic_to_new_or_healed_endpoints_in_minutes
+
+  dynamic "health_probe" {
+    for_each = var.enable_health_probe == true ? ["enable"] : []
+    content {
+      interval_in_seconds = var.health_probe_check_interval_in_seconds
+      path                = var.health_probe_path
+      protocol            = var.health_probe_protocol
+      request_type        = var.health_probe_request_type
+    }
+  }
+
+  load_balancing {
+    additional_latency_in_milliseconds = var.load_balancing_additional_latency_in_milliseconds
+    sample_size                        = var.load_balancing_sample_size
+    successful_samples_required        = var.load_balancing_successful_samples_required
+  }
+}
+
+resource "azurerm_cdn_frontdoor_origin" "cdn_frontdoor_public_origin" {
+  for_each                      = var.public_origins
+  name                          = each.key
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.cdn_frontdoor_origin_group.id
+  enabled                       = each.value.enabled
+
+  certificate_name_check_enabled = each.value.check_cert
+
+  host_name          = each.value.host_name
+  http_port          = each.value.http_port
+  https_port         = each.value.https_port
+  origin_host_header = each.value.origin_host_header
+  priority           = each.value.priority
+  weight             = each.value.weight
+}
+
+resource "azurerm_cdn_frontdoor_origin" "cdn_frontdoor_private_link_origin" {
+  for_each                      = var.private_link_origins
+  name                          = each.key
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.cdn_frontdoor_origin_group.id
+  enabled                       = each.value.enabled
+
+  certificate_name_check_enabled = true
+
+  host_name          = each.value.host_name
+  origin_host_header = each.value.origin_host_header
+  priority           = each.value.priority
+  weight             = each.value.weight
+
+  private_link {
+    target_type            = each.value.private_link_target_type
+    location               = each.value.private_link_location
+    private_link_target_id = each.value.private_link_target_id
+  }
+}
+
+resource "azurerm_cdn_frontdoor_origin" "cdn_frontdoor_private_link_service_origin" {
+  for_each                      = var.private_link_service_origins
+  name                          = each.key
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.cdn_frontdoor_origin_group.id
+  enabled                       = each.value.enabled
+
+  certificate_name_check_enabled = true
+
+  host_name          = each.value.host_name
+  origin_host_header = each.value.origin_host_header
+  priority           = each.value.priority
+  weight             = each.value.weight
+
+  private_link {
+    location               = each.value.private_link_location
+    private_link_target_id = each.value.private_link_target_id
+  }
+}

--- a/modules/azurerm/CDN-FrontDoor-Origin-Group/outputs.tf
+++ b/modules/azurerm/CDN-FrontDoor-Origin-Group/outputs.tf
@@ -1,0 +1,44 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "origin_group_id" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.cdn_frontdoor_origin_group]
+  value      = azurerm_cdn_frontdoor_origin_group.cdn_frontdoor_origin_group.id
+}
+
+output "origin_group_name" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.cdn_frontdoor_origin_group]
+  value      = azurerm_cdn_frontdoor_origin_group.cdn_frontdoor_origin_group.name
+}
+
+output "public_origin_ids" {
+  depends_on = [azurerm_cdn_frontdoor_origin.cdn_frontdoor_public_origin]
+  value      = { for origin in keys(var.public_origins) : origin => azurerm_cdn_frontdoor_origin.cdn_frontdoor_public_origin[origin].id }
+}
+
+output "private_link_origin_ids" {
+  depends_on = [azurerm_cdn_frontdoor_origin.cdn_frontdoor_private_link_origin]
+  value      = { for origin in keys(var.private_link_origins) : origin => azurerm_cdn_frontdoor_origin.cdn_frontdoor_private_link_origin[origin].id }
+}
+
+output "private_link_service_origin_ids" {
+  depends_on = [azurerm_cdn_frontdoor_origin.cdn_frontdoor_private_link_service_origin]
+  value      = { for origin in keys(var.private_link_service_origins) : origin => azurerm_cdn_frontdoor_origin.cdn_frontdoor_private_link_service_origin[origin].id }
+}

--- a/modules/azurerm/CDN-FrontDoor-Origin-Group/variables.tf
+++ b/modules/azurerm/CDN-FrontDoor-Origin-Group/variables.tf
@@ -1,0 +1,139 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "origin_group_name" {
+  description = "Name of the origin group"
+  type        = string
+}
+
+variable "origin_group_suffix" {
+  description = "Suffix of the origin group"
+  type        = string
+  default     = "origin-group"
+}
+
+variable "cdn_frontdoor_profile_id" {
+  description = "The ID of the CDN Front Door Profile within which the Origin Group should be created"
+  type        = string
+}
+
+variable "enable_session_affinity" {
+  description = "Should session affinity be enabled for this Origin Group?"
+  type        = bool
+  default     = false
+}
+
+variable "time_to_restore_traffic_to_new_or_healed_endpoints_in_minutes" {
+  description = "The time in minutes to restore traffic to a new or healed endpoint"
+  type        = number
+  default     = 5
+}
+
+variable "enable_health_probe" {
+  description = "Should health probes be enabled for this Origin Group?"
+  type        = bool
+  default     = false
+}
+
+variable "health_probe_check_interval_in_seconds" {
+  description = "The interval in seconds between health probes"
+  type        = number
+  default     = 30
+}
+
+variable "health_probe_path" {
+  description = "The path to use for health probes"
+  type        = string
+  default     = "/"
+}
+
+variable "health_probe_protocol" {
+  description = "The protocol to use for health probes"
+  type        = string
+  default     = "Https"
+}
+
+variable "health_probe_request_type" {
+  description = "The request type to use for health probes"
+  type        = string
+  default     = "HEAD"
+}
+
+variable "load_balancing_additional_latency_in_milliseconds" {
+  description = "The additional latency in milliseconds to add to the load balancing algorithm"
+  type        = number
+  default     = 0
+}
+
+variable "load_balancing_sample_size" {
+  description = "The number of samples to take for load balancing"
+  type        = number
+  default     = 4
+}
+
+variable "load_balancing_successful_samples_required" {
+  description = "The number of successful samples required for load balancing"
+  type        = number
+  default     = 2
+}
+
+variable "public_origins" {
+  description = "A map of public origins to create within the Origin Group"
+  type = map(object({
+    enabled            = bool
+    check_cert         = bool
+    host_name          = string
+    http_port          = number
+    https_port         = number
+    origin_host_header = string
+    priority           = number
+    weight             = number
+  }))
+  default = {}
+}
+
+variable "private_link_origins" {
+  description = "A map of private link origins to create within the Origin Group"
+  type = map(object({
+    enabled                  = bool
+    host_name                = string
+    origin_host_header       = string
+    priority                 = number
+    weight                   = number
+    private_link_target_type = string
+    private_link_location    = string
+    private_link_target_id   = string
+  }))
+  default = {}
+}
+
+variable "private_link_service_origins" {
+  description = "A map of private link service origins to create within the Origin Group"
+  type = map(object({
+    enabled                = bool
+    host_name              = string
+    origin_host_header     = string
+    priority               = number
+    weight                 = number
+    private_link_location  = string
+    private_link_target_id = string
+  }))
+  default = {}
+}

--- a/modules/azurerm/CDN-FrontDoor-Origin-Group/versions.tf
+++ b/modules/azurerm/CDN-FrontDoor-Origin-Group/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.52.0"
+    }
+  }
+}

--- a/modules/azurerm/CDN-FrontDoor-Profile/cdn_frontdoor_profile.tf
+++ b/modules/azurerm/CDN-FrontDoor-Profile/cdn_frontdoor_profile.tf
@@ -1,0 +1,27 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_cdn_frontdoor_profile" "cdn_frontdoor_profile" {
+  name                     = join("-", [var.frontdoor_abbreviation, var.frontdoor_profile_name])
+  resource_group_name      = var.resource_group_name
+  sku_name                 = var.sku_name
+  response_timeout_seconds = var.response_timeout_seconds
+  tags                     = var.tags
+}

--- a/modules/azurerm/CDN-FrontDoor-Profile/outputs.tf
+++ b/modules/azurerm/CDN-FrontDoor-Profile/outputs.tf
@@ -1,0 +1,34 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "id" {
+  depends_on = [azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile]
+  value      = azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile.id
+}
+
+output "name" {
+  depends_on = [azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile]
+  value      = azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile.name
+}
+
+output "resource_guid" {
+  depends_on = [azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile]
+  value      = azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile.resource_guid
+}

--- a/modules/azurerm/CDN-FrontDoor-Profile/variables.tf
+++ b/modules/azurerm/CDN-FrontDoor-Profile/variables.tf
@@ -1,0 +1,53 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "frontdoor_abbreviation" {
+  description = "The abbreviation of the Front Door Profile."
+  type        = string
+  default     = "fd"
+}
+
+variable "frontdoor_profile_name" {
+  description = "The name of the Front Door Profile."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group in which to create the Front Door Profile."
+  type        = string
+}
+
+variable "sku_name" {
+  description = "Specifies the SKU for this Front Door Profile. Possible values include Standard_AzureFrontDoor and Premium_AzureFrontDoor."
+  type        = string
+  default     = "Standard_AzureFrontDoor"
+}
+
+variable "response_timeout_seconds" {
+  description = "The response timeout for the Front Door Profile."
+  type        = number
+  default     = 240
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to the resource."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/azurerm/CDN-FrontDoor-Profile/versions.tf
+++ b/modules/azurerm/CDN-FrontDoor-Profile/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.52.0"
+    }
+  }
+}

--- a/modules/azurerm/CDN-FrontDoor-Route/cdn_frontdoor_route.tf
+++ b/modules/azurerm/CDN-FrontDoor-Route/cdn_frontdoor_route.tf
@@ -1,0 +1,47 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_cdn_frontdoor_route" "cdn_frontdoor_route" {
+  name                          = var.route_name
+  cdn_frontdoor_endpoint_id     = var.cdn_frontdoor_endpoint_id
+  cdn_frontdoor_origin_group_id = var.cdn_frontdoor_origin_group_id
+  cdn_frontdoor_origin_ids      = var.cdn_frontdoor_origin_ids
+  cdn_frontdoor_rule_set_ids    = var.cdn_frontdoor_rule_set_ids
+  enabled                       = var.enable_route
+
+  forwarding_protocol    = var.forwarding_protocol
+  https_redirect_enabled = var.https_redirect_enabled
+  patterns_to_match      = var.patterns_to_match
+  supported_protocols    = var.supported_protocols
+
+  cdn_frontdoor_custom_domain_ids = var.cdn_frontdoor_custom_domain_ids
+  link_to_default_domain          = var.link_to_default_domain
+  cdn_frontdoor_origin_path       = var.cdn_frontdoor_origin_path
+
+  dynamic "cache" {
+    for_each = var.enable_cache == true ? ["cache"] : []
+    content {
+      query_string_caching_behavior = var.cache_query_string_caching_behavior
+      query_strings                 = var.cache_query_strings
+      compression_enabled           = var.cache_compression_enabled
+      content_types_to_compress     = var.cache_content_types_to_compress
+    }
+  }
+}

--- a/modules/azurerm/CDN-FrontDoor-Route/outputs.tf
+++ b/modules/azurerm/CDN-FrontDoor-Route/outputs.tf
@@ -1,0 +1,24 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "id" {
+  depends_on = [azurerm_cdn_frontdoor_route.cdn_frontdoor_route]
+  value      = azurerm_cdn_frontdoor_route.cdn_frontdoor_route.id
+}

--- a/modules/azurerm/CDN-FrontDoor-Route/variables.tf
+++ b/modules/azurerm/CDN-FrontDoor-Route/variables.tf
@@ -1,0 +1,120 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "route_name" {
+  description = "The name of the route."
+  type        = string
+}
+
+variable "cdn_frontdoor_endpoint_id" {
+  description = "The ID of the Front Door Endpoint."
+  type        = string
+}
+
+variable "cdn_frontdoor_origin_group_id" {
+  description = "The ID of the Front Door Origin Group."
+  type        = string
+}
+
+variable "cdn_frontdoor_origin_ids" {
+  description = "The IDs of the Front Door Origins."
+  type        = list(string)
+}
+
+variable "cdn_frontdoor_rule_set_ids" {
+  description = "The IDs of the Front Door Rule Sets."
+  type        = list(string)
+}
+
+variable "enable_route" {
+  description = "Is the route enabled?"
+  type        = bool
+  default     = true
+}
+
+variable "forwarding_protocol" {
+  description = "The protocol to use for forwarding traffic."
+  type        = string
+  default     = "HttpsOnly"
+}
+
+variable "https_redirect_enabled" {
+  description = "Is HTTPS redirect enabled?"
+  type        = bool
+  default     = false
+}
+
+variable "patterns_to_match" {
+  description = "The patterns to match for the route."
+  type        = list(string)
+  default     = ["/*"]
+}
+
+variable "supported_protocols" {
+  description = "The supported protocols for the route."
+  type        = list(string)
+  default     = ["Https"]
+}
+
+variable "cdn_frontdoor_custom_domain_ids" {
+  description = "The IDs of the Front Door Custom Domains."
+  type        = list(string)
+}
+
+variable "link_to_default_domain" {
+  description = "Link to the default domain?"
+  type        = bool
+  default     = false
+}
+
+variable "cdn_frontdoor_origin_path" {
+  description = "The path to the Front Door Origin."
+  type        = string
+}
+
+variable "enable_cache" {
+  description = "Is caching enabled?"
+  type        = bool
+  default     = false
+}
+
+variable "cache_query_string_caching_behavior" {
+  description = "The query string caching behavior."
+  type        = string
+  default     = "IgnoreQueryString"
+}
+
+variable "cache_query_strings" {
+  description = "The query strings to cache."
+  type        = list(string)
+  default     = []
+}
+
+variable "cache_compression_enabled" {
+  description = "Is compression enabled?"
+  type        = bool
+  default     = false
+}
+
+variable "cache_content_types_to_compress" {
+  description = "The content types to compress."
+  type        = list(string)
+  default     = []
+}

--- a/modules/azurerm/CDN-FrontDoor-Route/versions.tf
+++ b/modules/azurerm/CDN-FrontDoor-Route/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.52.0"
+    }
+  }
+}

--- a/modules/azurerm/CDN-FrontDoor-Rule-Set/cdn_frontdoor_rule_set.tf
+++ b/modules/azurerm/CDN-FrontDoor-Rule-Set/cdn_frontdoor_rule_set.tf
@@ -1,0 +1,271 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_cdn_frontdoor_rule_set" "cdn_frontdoor_rule_set" {
+  name                     = var.rule_set_name
+  cdn_frontdoor_profile_id = var.cdn_frontdoor_profile_id
+}
+
+resource "azurerm_cdn_frontdoor_rule" "cdn_frontdoor_rule" {
+  for_each                  = var.rules
+  name                      = each.key
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.cdn_frontdoor_rule_set.id
+  order                     = each.value.order
+  behavior_on_match         = each.value.behavior_on_match
+
+  actions {
+    dynamic "url_rewrite_action" {
+      for_each = each.value.url_rewrite_actions
+      content {
+        source_pattern          = url_rewrite_action.value.source_pattern
+        destination             = url_rewrite_action.value.destination
+        preserve_unmatched_path = url_rewrite_action.value.preserve_unmatched_path
+      }
+    }
+
+    dynamic "url_redirect_action" {
+      for_each = each.value.url_redirect_actions
+      content {
+        redirect_type        = url_redirect_action.value.redirect_type
+        destination_hostname = url_redirect_action.value.destination_hostname
+        redirect_protocol    = url_redirect_action.value.redirect_protocol
+        destination_path     = url_redirect_action.value.destination_path
+        query_string         = url_redirect_action.value.query_string
+        destination_fragment = url_redirect_action.value.destination_fragment
+      }
+    }
+
+    dynamic "route_configuration_override_action" {
+      for_each = each.value.route_configuration_override_actions
+      content {
+        cache_duration                = route_configuration_override_action.value.cache_duration
+        cdn_frontdoor_origin_group_id = route_configuration_override_action.value.cdn_frontdoor_origin_group_id
+        forwarding_protocol           = route_configuration_override_action.value.forwarding_protocol
+        query_string_caching_behavior = route_configuration_override_action.value.query_string_caching_behavior
+        query_string_parameters       = route_configuration_override_action.value.query_string_parameters
+        compression_enabled           = route_configuration_override_action.value.compression_enabled
+        cache_behavior                = route_configuration_override_action.value.cache_behavior
+      }
+    }
+
+    dynamic "request_header_action" {
+      for_each = each.value.request_header_actions
+      content {
+        header_action = request_header_action.value.header_action
+        header_name   = request_header_action.value.header_name
+        value         = request_header_action.value.value
+      }
+    }
+
+    dynamic "response_header_action" {
+      for_each = each.value.response_header_actions
+      content {
+        header_action = response_header_action.value.header_action
+        header_name   = response_header_action.value.header_name
+        value         = response_header_action.value.value
+      }
+    }
+  }
+
+  conditions {
+    dynamic "remote_address_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "remote_address" }
+      content {
+        match_values     = remote_address_condition.value.match_values
+        operator         = remote_address_condition.value.operator
+        negate_condition = remote_address_condition.value.negate_condition
+      }
+    }
+
+    dynamic "request_method_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "request_method" }
+      content {
+        match_values     = request_method_condition.value.match_values
+        operator         = request_method_condition.value.operator
+        negate_condition = request_method_condition.value.negate_condition
+      }
+    }
+
+    dynamic "query_string_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "query_string" }
+      content {
+        match_values     = query_string_condition.value.match_values
+        operator         = query_string_condition.value.operator
+        negate_condition = query_string_condition.value.negate_condition
+        transforms       = query_string_condition.value.transforms
+      }
+    }
+
+    dynamic "post_args_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "post_args" }
+      content {
+        post_args_name   = post_args_condition.value.object_name
+        match_values     = post_args_condition.value.match_values
+        operator         = post_args_condition.value.operator
+        negate_condition = post_args_condition.value.negate_condition
+        transforms       = post_args_condition.value.transforms
+      }
+    }
+
+    dynamic "request_uri_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "request_uri" }
+      content {
+        match_values     = request_uri_condition.value.match_values
+        operator         = request_uri_condition.value.operator
+        negate_condition = request_uri_condition.value.negate_condition
+        transforms       = request_uri_condition.value.transforms
+      }
+    }
+
+    dynamic "request_header_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "request_header" }
+      content {
+        match_values     = request_header_condition.value.match_values
+        operator         = request_header_condition.value.operator
+        negate_condition = request_header_condition.value.negate_condition
+        transforms       = request_header_condition.value.transforms
+        header_name      = request_header_condition.value.object_name
+      }
+    }
+
+    dynamic "request_body_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "request_body" }
+      content {
+        match_values     = request_body_condition.value.match_values
+        operator         = request_body_condition.value.operator
+        negate_condition = request_body_condition.value.negate_condition
+        transforms       = request_body_condition.value.transforms
+      }
+    }
+
+    dynamic "request_scheme_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "request_scheme" }
+      content {
+        match_values     = request_scheme_condition.value.match_values
+        operator         = request_scheme_condition.value.operator
+        negate_condition = request_scheme_condition.value.negate_condition
+      }
+    }
+
+    dynamic "url_path_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "url_path" }
+      content {
+        match_values     = url_path_condition.value.match_values
+        operator         = url_path_condition.value.operator
+        negate_condition = url_path_condition.value.negate_condition
+        transforms       = url_path_condition.value.transforms
+      }
+    }
+
+    dynamic "url_file_extension_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "url_file_extension" }
+      content {
+        match_values     = url_file_extension_condition.value.match_values
+        operator         = url_file_extension_condition.value.operator
+        negate_condition = url_file_extension_condition.value.negate_condition
+        transforms       = url_file_extension_condition.value.transforms
+      }
+    }
+
+    dynamic "url_filename_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "url_filename" }
+      content {
+        match_values     = url_filename_condition.value.match_values
+        operator         = url_filename_condition.value.operator
+        negate_condition = url_filename_condition.value.negate_condition
+        transforms       = url_filename_condition.value.transforms
+      }
+    }
+
+    dynamic "http_version_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "http_version" }
+      content {
+        match_values     = http_version_condition.value.match_values
+        operator         = http_version_condition.value.operator
+        negate_condition = http_version_condition.value.negate_condition
+      }
+    }
+
+    dynamic "cookies_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "cookies" }
+      content {
+        match_values     = cookies_condition.value.match_values
+        operator         = cookies_condition.value.operator
+        negate_condition = cookies_condition.value.negate_condition
+        transforms       = cookies_condition.value.transforms
+        cookie_name      = cookies_condition.value.object_name
+      }
+    }
+
+    dynamic "is_device_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "is_device" }
+      content {
+        match_values     = is_device_condition.value.match_values
+        operator         = is_device_condition.value.operator
+        negate_condition = is_device_condition.value.negate_condition
+      }
+    }
+
+    dynamic "socket_address_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "socket_address" }
+      content {
+        match_values     = socket_address_condition.value.match_values
+        operator         = socket_address_condition.value.operator
+        negate_condition = socket_address_condition.value.negate_condition
+      }
+    }
+
+    dynamic "client_port_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "client_port" }
+      content {
+        match_values     = client_port_condition.value.match_values
+        operator         = client_port_condition.value.operator
+        negate_condition = client_port_condition.value.negate_condition
+      }
+    }
+
+    dynamic "server_port_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "server_port" }
+      content {
+        match_values     = server_port_condition.value.match_values
+        operator         = server_port_condition.value.operator
+        negate_condition = server_port_condition.value.negate_condition
+      }
+    }
+
+    dynamic "host_name_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "host_name" }
+      content {
+        match_values = host_name_condition.value.match_values
+        operator     = host_name_condition.value.operator
+        transforms   = host_name_condition.value.transforms
+      }
+    }
+
+    dynamic "ssl_protocol_condition" {
+      for_each = { for k, v in each.value.conditions : k => v if v.type == "ssl_protocol" }
+      content {
+        match_values     = ssl_protocol_condition.value.match_values
+        operator         = ssl_protocol_condition.value.operator
+        negate_condition = ssl_protocol_condition.value.negate_condition
+      }
+    }
+  }
+}

--- a/modules/azurerm/CDN-FrontDoor-Rule-Set/outputs.tf
+++ b/modules/azurerm/CDN-FrontDoor-Rule-Set/outputs.tf
@@ -1,0 +1,24 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "rule_set_id" {
+  depends_on = [azurerm_cdn_frontdoor_rule_set.cdn_frontdoor_rule_set]
+  value      = azurerm_cdn_frontdoor_rule_set.cdn_frontdoor_rule_set.id
+}

--- a/modules/azurerm/CDN-FrontDoor-Rule-Set/variables.tf
+++ b/modules/azurerm/CDN-FrontDoor-Rule-Set/variables.tf
@@ -1,0 +1,84 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "rule_set_name" {
+  description = "Name of the rule set"
+  type        = string
+}
+
+variable "cdn_frontdoor_profile_id" {
+  description = "The ID of the CDN Front Door Profile within which the Rule Set should be created"
+  type        = string
+}
+
+variable "rules" {
+  description = "A list of rules to be included in the Rule Set"
+  type = map(object({
+    order             = number
+    behavior_on_match = string
+
+    url_rewrite_actions = list(object({
+      source_pattern          = string
+      destination             = string
+      preserve_unmatched_path = bool
+    }))
+
+    url_redirect_actions = list(object({
+      redirect_type        = string
+      destination_hostname = string
+      redirect_protocol    = string
+      destination_path     = string
+      query_string         = string
+      destination_fragment = string
+    }))
+
+    route_configuration_override_actions = list(object({
+      cache_duration                = number
+      cdn_frontdoor_origin_group_id = string
+      forwarding_protocol           = string
+      query_string_caching_behavior = string
+      query_string_parameters       = list(string)
+      compression_enabled           = bool
+      cache_behavior                = string
+    }))
+
+    request_header_actions = list(object({
+      header_action = string
+      header_name   = string
+      value         = string
+    }))
+
+    response_header_actions = list(object({
+      header_action = string
+      header_name   = string
+      value         = string
+    }))
+
+    conditions = map(object({
+      type             = string
+      match_values     = list(string)
+      operator         = string
+      negate_condition = bool
+      transforms       = list(string)
+      object_name      = string
+    }))
+
+  }))
+}

--- a/modules/azurerm/CDN-FrontDoor-Rule-Set/versions.tf
+++ b/modules/azurerm/CDN-FrontDoor-Rule-Set/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.52.0"
+    }
+  }
+}

--- a/modules/azurerm/Storage-Account-Blob-Cors/variables.tf
+++ b/modules/azurerm/Storage-Account-Blob-Cors/variables.tf
@@ -41,7 +41,7 @@ variable "tags" {
 }
 
 variable "default_action" {
-  default     = "Allow"
+  default     = "Deny"
   description = "The default action of allow or deny when no other rules match"
   type        = string
 }

--- a/modules/azurerm/Storage-Account-Blob/variables.tf
+++ b/modules/azurerm/Storage-Account-Blob/variables.tf
@@ -41,7 +41,7 @@ variable "tags" {
 }
 
 variable "default_action" {
-  default     = "Allow"
+  default     = "Deny"
   description = "The default action of allow or deny when no other rules match"
   type        = string
 }

--- a/modules/azurerm/Storage-Account-File/variables.tf
+++ b/modules/azurerm/Storage-Account-File/variables.tf
@@ -62,7 +62,7 @@ variable "daily_retention" {
 }
 
 variable "storage_account_network_rules_default_action" {
-  default     = "Allow"
+  default     = "Deny"
   description = "The default action of allow or deny when no other rules match"
   type        = string
 }

--- a/modules/azurerm/Storage-Account-Static-Website/storage_account_static_website.tf
+++ b/modules/azurerm/Storage-Account-Static-Website/storage_account_static_website.tf
@@ -32,6 +32,7 @@ resource "azurerm_storage_account" "static_storage" {
     default_action             = var.network_rules_default_action
     ip_rules                   = var.network_rules_ip_whitelist
     virtual_network_subnet_ids = var.network_rules_subnet_ids
+    bypass                     = var.network_rules_bypass
   }
 
   static_website {

--- a/modules/azurerm/Storage-Account-Static-Website/variables.tf
+++ b/modules/azurerm/Storage-Account-Static-Website/variables.tf
@@ -56,7 +56,7 @@ variable "network_rules_ip_whitelist" {
 }
 
 variable "network_rules_default_action" {
-  default     = "Allow"
+  default     = "Deny"
   description = "The default action of allow or deny when no other rules match"
   type        = string
 }
@@ -71,4 +71,10 @@ variable "allow_nested_items_to_be_public" {
   default     = false
   description = "Allow or disallow nested items within this Account to opt into being public"
   type        = bool
+}
+
+variable "network_rules_bypass" {
+  default     = []
+  description = "List of actions that bypass the network rule. Defaults to []"
+  type        = list(string)
 }

--- a/modules/azurerm/Synapse-Workspace-Storage-Account/variables.tf
+++ b/modules/azurerm/Synapse-Workspace-Storage-Account/variables.tf
@@ -33,11 +33,6 @@ variable "location" {
   type        = string
 }
 
-variable "storage_data_lake_gen2_filesystem_id" {
-  description = "The ID of the Data Lake Storage Gen2 Filesystem to be used by the Synapse Workspace"
-  type        = string
-}
-
 variable "sql_administrator_login" {
   description = "The username of the SQL Administrator"
   type        = string


### PR DESCRIPTION
## Purpose

Add CDN FrontDoor modules related to the following 

- https://registry.terraform.io/providers/hashicorp/azurerm/3.52.0/docs/resources/cdn_frontdoor_custom_domain
- https://registry.terraform.io/providers/hashicorp/azurerm/3.52.0/docs/resources/cdn_frontdoor_custom_domain_association
- https://registry.terraform.io/providers/hashicorp/azurerm/3.52.0/docs/resources/cdn_frontdoor_endpoint
- https://registry.terraform.io/providers/hashicorp/azurerm/3.52.0/docs/resources/cdn_frontdoor_origin
- https://registry.terraform.io/providers/hashicorp/azurerm/3.52.0/docs/resources/cdn_frontdoor_origin_group
- https://registry.terraform.io/providers/hashicorp/azurerm/3.52.0/docs/resources/cdn_frontdoor_profile
- https://registry.terraform.io/providers/hashicorp/azurerm/3.52.0/docs/resources/cdn_frontdoor_route
- https://registry.terraform.io/providers/hashicorp/azurerm/3.52.0/docs/resources/cdn_frontdoor_rule
- https://registry.terraform.io/providers/hashicorp/azurerm/3.52.0/docs/resources/cdn_frontdoor_rule_set