### PR TITLE
Add WEBSITE_RUN_FROM_PACKAGE to the lifecycle ignore changes

### DIFF
--- a/modules/azurerm/Linux-Function-App/linux_function_app.tf
+++ b/modules/azurerm/Linux-Function-App/linux_function_app.tf
@@ -112,7 +112,8 @@ resource "azurerm_linux_function_app" "linux_function_app" {
     ignore_changes = [
       tags["hidden-link: /app-insights-conn-string"],
       tags["hidden-link: /app-insights-instrumentation-key"],
-      tags["hidden-link: /app-insights-resource-id"]
+      tags["hidden-link: /app-insights-resource-id"],
+      app_settings["WEBSITE_RUN_FROM_PACKAGE"]
     ]
   }
 }


### PR DESCRIPTION
## Purpose

This is to add WEBSITE_RUN_FROM_PACKAGE for lifecycle ignore changes. For any linux function app in consumption plan, the WEBSITE_RUN_FROM_PACKAGE set to storage account container SAS endpoint which will be changing in each deployment. This is to avoid terraform diffs per each deployment