### PR TITLE
Update AzureRM Modules to Support  4.x.x Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased] - yyyy-mm-dd
+## [Unreleased]
+
+### Added
+
+### Changed
+
+- Update AzureRM modules to support AzureRM 4.x.x changes
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
 
 ## [v2.0.0] - 2025-01-06
 

--- a/modules/azurerm/AKS-Firewall/aks_cluster.tf
+++ b/modules/azurerm/AKS-Firewall/aks_cluster.tf
@@ -15,7 +15,6 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
   resource_group_name                 = var.resource_group_name
   dns_prefix                          = join("-", ["aks", var.aks_cluster_dns_prefix])
   kubernetes_version                  = var.kubernetes_version
-  api_server_authorized_ip_ranges     = var.api_server_authorized_ip_ranges
   node_resource_group                 = join("-", ["rg", var.aks_node_pool_resource_group_name])
   sku_tier                            = var.sku_tier
   private_cluster_enabled             = var.private_cluster_enabled
@@ -26,6 +25,8 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
   http_application_routing_enabled    = var.http_application_routing_enabled
   workload_identity_enabled           = var.workload_identity_enabled
   oidc_issuer_enabled                 = var.oidc_issuer_enabled
+  image_cleaner_interval_hours        = var.image_cleaner_interval_hours
+  node_os_upgrade_channel             = var.node_os_upgrade_channel
   tags                                = var.tags
   depends_on                          = [azurerm_subnet.aks_node_pool_subnet, azurerm_subnet_route_table_association.subnet_rt_association]
 
@@ -37,6 +38,10 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
       default_node_pool[0].orchestrator_version,
       microsoft_defender
     ]
+  }
+
+  api_server_access_profile {
+    authorized_ip_ranges = var.api_server_authorized_ip_ranges
   }
 
   linux_profile {
@@ -53,14 +58,20 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
     zones                        = var.default_node_pool_availability_zones
     os_disk_size_gb              = var.default_node_pool_os_disk_size_gb
     os_disk_type                 = var.default_node_pool_os_disk_type
-    enable_auto_scaling          = var.default_node_pool_enable_auto_scaling
+    auto_scaling_enabled         = var.default_node_pool_enable_auto_scaling
     vnet_subnet_id               = azurerm_subnet.aks_node_pool_subnet.id
     max_count                    = var.default_node_pool_max_count
     min_count                    = var.default_node_pool_min_count
     max_pods                     = var.default_node_pool_max_pods
     orchestrator_version         = var.default_node_pool_orchestrator_version
-    enable_node_public_ip        = false
+    node_public_ip_enabled       = false
     only_critical_addons_enabled = var.default_node_pool_only_critical_addons_enabled
+
+    upgrade_settings {
+      drain_timeout_in_minutes      = var.default_node_pool_drain_timeout_in_minutes
+      node_soak_duration_in_minutes = var.default_node_pool_soak_duration_in_minutes
+      max_surge                     = var.default_node_pool_max_surge
+    }
   }
 
   dynamic "identity" {
@@ -79,7 +90,6 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
   }
 
   azure_active_directory_role_based_access_control {
-    managed                = true
     admin_group_object_ids = var.aks_admin_group_object_ids
     azure_rbac_enabled     = var.aks_azure_rbac_enabled
   }
@@ -89,13 +99,12 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
   }
 
   network_profile {
-    network_plugin     = "azure"
-    network_policy     = "calico"
-    load_balancer_sku  = "standard"
-    service_cidr       = var.service_cidr
-    dns_service_ip     = var.dns_service_ip
-    docker_bridge_cidr = var.docker_bridge_cidr
-    outbound_type      = "userDefinedRouting"
+    network_plugin    = "azure"
+    network_policy    = "calico"
+    load_balancer_sku = "standard"
+    service_cidr      = var.service_cidr
+    dns_service_ip    = var.dns_service_ip
+    outbound_type     = "userDefinedRouting"
   }
 
   dynamic "key_vault_secrets_provider" {

--- a/modules/azurerm/AKS-Firewall/network.tf
+++ b/modules/azurerm/AKS-Firewall/network.tf
@@ -10,12 +10,12 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_subnet" "aks_node_pool_subnet" {
-  name                                      = join("-", ["snet", var.aks_node_pool_subnet_name])
-  resource_group_name                       = var.resource_group_name
-  virtual_network_name                      = var.virtual_network_name
-  address_prefixes                          = [var.aks_node_pool_subnet_address_prefix]
-  service_endpoints                         = ["Microsoft.Sql", "Microsoft.ContainerRegistry", "Microsoft.EventHub", "Microsoft.Storage"]
-  private_endpoint_network_policies_enabled = var.aks_nodepool_subnet_enforce_private_link_endpoint_network_policies
+  name                              = join("-", ["snet", var.aks_node_pool_subnet_name])
+  resource_group_name               = var.resource_group_name
+  virtual_network_name              = var.virtual_network_name
+  address_prefixes                  = [var.aks_node_pool_subnet_address_prefix]
+  service_endpoints                 = ["Microsoft.Sql", "Microsoft.ContainerRegistry", "Microsoft.EventHub", "Microsoft.Storage"]
+  private_endpoint_network_policies = var.aks_nodepool_subnet_private_endpoint_network_policies
 }
 
 resource "azurerm_route_table" "aks_node_pool_route_table" {
@@ -158,12 +158,12 @@ resource "azurerm_subnet_network_security_group_association" "aks_node_pool_subn
 }
 
 resource "azurerm_subnet" "internal_load_balancer_subnet" {
-  name                                      = join("-", ["snet", var.aks_load_balancer_subnet_name])
-  resource_group_name                       = var.resource_group_name
-  virtual_network_name                      = var.virtual_network_name
-  address_prefixes                          = [var.internal_loadbalancer_subnet_address_prefix]
-  service_endpoints                         = ["Microsoft.Sql", "Microsoft.ContainerRegistry", "Microsoft.EventHub", "Microsoft.Storage"]
-  private_endpoint_network_policies_enabled = var.internal_load_balancer_subnet_enforce_private_link_endpoint_network_policies
+  name                              = join("-", ["snet", var.aks_load_balancer_subnet_name])
+  resource_group_name               = var.resource_group_name
+  virtual_network_name              = var.virtual_network_name
+  address_prefixes                  = [var.internal_loadbalancer_subnet_address_prefix]
+  service_endpoints                 = ["Microsoft.Sql", "Microsoft.ContainerRegistry", "Microsoft.EventHub", "Microsoft.Storage"]
+  private_endpoint_network_policies = var.internal_load_balancer_subnet_private_endpoint_network_policies
 }
 
 resource "azurerm_network_security_group" "internal_load_balancer_subnet_nsg" {

--- a/modules/azurerm/AKS-Firewall/variables.tf
+++ b/modules/azurerm/AKS-Firewall/variables.tf
@@ -167,11 +167,6 @@ variable "dns_service_ip" {
   type        = string
 }
 
-variable "docker_bridge_cidr" {
-  description = "Docker bridge CIDR"
-  type        = string
-}
-
 variable "log_analytics_workspace_id" {
   description = "Log analytics workspace id"
   type        = string
@@ -238,16 +233,16 @@ variable "private_cluster_public_fqdn_enable" {
   type        = bool
 }
 
-variable "aks_nodepool_subnet_enforce_private_link_endpoint_network_policies" {
-  default     = false
-  description = "Enable or Disable network policies for the private link endpoint on the aks nodepool subnet"
-  type        = bool
+variable "aks_nodepool_subnet_private_endpoint_network_policies" {
+  default     = "Disabled"
+  description = "Enable or Disable network policies for the private endpoint on the subnet. Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled"
+  type        = string
 }
 
-variable "internal_load_balancer_subnet_enforce_private_link_endpoint_network_policies" {
-  default     = false
-  description = "Enable or Disable network policies for the private link endpoint on the internal load balancer subnet"
-  type        = bool
+variable "internal_load_balancer_subnet_private_endpoint_network_policies" {
+  default     = "Disabled"
+  description = "Enable or Disable network policies for the private endpoint on the subnet. Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled"
+  type        = string
 }
 
 variable "private_dns_zone_id" {
@@ -301,4 +296,34 @@ variable "secret_rotation_enabled" {
   description = "Enable secret rotation"
   type        = bool
   default     = false
+}
+
+variable "default_node_pool_drain_timeout_in_minutes" {
+  description = "Default node pool drain timeout in minutes"
+  type        = number
+  default     = 30
+}
+
+variable "default_node_pool_soak_duration_in_minutes" {
+  description = "Default node pool soak duration in minutes"
+  type        = number
+  default     = 0
+}
+
+variable "default_node_pool_max_surge" {
+  description = "Default node pool max surge"
+  type        = string
+  default     = "33%"
+}
+
+variable "image_cleaner_interval_hours" {
+  description = "Image cleaner interval hours"
+  type        = number
+  default     = 48
+}
+
+variable "node_os_upgrade_channel" {
+  description = "Node OS upgrade channel"
+  type        = string
+  default     = "NodeImage"
 }

--- a/modules/azurerm/AKS-Firewall/versions.tf
+++ b/modules/azurerm/AKS-Firewall/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/azurerm/AKS-Node-Pool/aks_node_pool.tf
+++ b/modules/azurerm/AKS-Node-Pool/aks_node_pool.tf
@@ -10,23 +10,29 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_kubernetes_cluster_node_pool" "kubernetes_cluster_node_pool" {
-  name                  = join("", ["aksnp", var.node_pool_name])
-  node_count            = var.node_pool_count
-  vm_size               = var.node_pool_vm_size
-  zones                 = var.node_pool_availability_zones
-  os_disk_size_gb       = var.node_pool_os_disk_size_gb
-  os_disk_type          = var.node_pool_os_disk_type
-  enable_auto_scaling   = var.node_pool_enable_auto_scaling
-  vnet_subnet_id        = var.aks_subnet_id
-  kubernetes_cluster_id = var.aks_cluster_id
-  max_count             = var.node_pool_max_count
-  min_count             = var.node_pool_min_count
-  max_pods              = var.node_pool_max_pods
-  orchestrator_version  = var.node_pool_orchestrator_version
-  enable_node_public_ip = false
-  mode                  = var.node_pool_mode
-  os_type               = var.node_pool_os_type
-  tags                  = var.tags
+  name                   = join("", ["aksnp", var.node_pool_name])
+  node_count             = var.node_pool_count
+  vm_size                = var.node_pool_vm_size
+  zones                  = var.node_pool_availability_zones
+  os_disk_size_gb        = var.node_pool_os_disk_size_gb
+  os_disk_type           = var.node_pool_os_disk_type
+  auto_scaling_enabled   = var.node_pool_enable_auto_scaling
+  vnet_subnet_id         = var.aks_subnet_id
+  kubernetes_cluster_id  = var.aks_cluster_id
+  max_count              = var.node_pool_max_count
+  min_count              = var.node_pool_min_count
+  max_pods               = var.node_pool_max_pods
+  orchestrator_version   = var.node_pool_orchestrator_version
+  node_public_ip_enabled = false
+  mode                   = var.node_pool_mode
+  os_type                = var.node_pool_os_type
+  tags                   = var.tags
+
+  upgrade_settings {
+    drain_timeout_in_minutes      = var.node_pool_upgrade_drain_timeout
+    node_soak_duration_in_minutes = var.node_pool_upgrade_soak_duration
+    max_surge                     = var.node_pool_upgrade_max_surge
+  }
 
   lifecycle {
     ignore_changes = [

--- a/modules/azurerm/AKS-Node-Pool/variables.tf
+++ b/modules/azurerm/AKS-Node-Pool/variables.tf
@@ -92,3 +92,21 @@ variable "tags" {
   description = "Tags to be used in the resource tags"
   type        = map(string)
 }
+
+variable "node_pool_upgrade_drain_timeout" {
+  default     = 30
+  description = "Drain timeout in minutes for node pool upgrades"
+  type        = number
+}
+
+variable "node_pool_upgrade_soak_duration" {
+  default     = 0
+  description = "Soak duration in minutes for node pool upgrades"
+  type        = number
+}
+
+variable "node_pool_upgrade_max_surge" {
+  default     = "33%"
+  description = "Maximum surge for node pool upgrades"
+  type        = string
+}

--- a/modules/azurerm/AKS-Node-Pool/versions.tf
+++ b/modules/azurerm/AKS-Node-Pool/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
     random = ">= 2.2"
   }

--- a/modules/azurerm/Application-Gateway/subnet.tf
+++ b/modules/azurerm/Application-Gateway/subnet.tf
@@ -10,10 +10,10 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_subnet" "app_gateway_subnet" {
-  name                                      = join("-", [var.subnet_abbreviation, var.application_gateway_subnet_name])
-  resource_group_name                       = var.resource_group_name
-  virtual_network_name                      = var.virtual_network_name
-  address_prefixes                          = var.address_prefixes
-  service_endpoints                         = var.service_endpoints
-  private_endpoint_network_policies_enabled = var.app_gateway_subnet_enforce_private_link_endpoint_network_policies
+  name                              = join("-", [var.subnet_abbreviation, var.application_gateway_subnet_name])
+  resource_group_name               = var.resource_group_name
+  virtual_network_name              = var.virtual_network_name
+  address_prefixes                  = var.address_prefixes
+  service_endpoints                 = var.service_endpoints
+  private_endpoint_network_policies = var.private_endpoint_network_policies
 }

--- a/modules/azurerm/Application-Gateway/variables.tf
+++ b/modules/azurerm/Application-Gateway/variables.tf
@@ -284,10 +284,10 @@ variable "tags" {
   type        = map(string)
 }
 
-variable "app_gateway_subnet_enforce_private_link_endpoint_network_policies" {
-  default     = false
-  description = "Enable or Disable network policies for the private link endpoint on the application gateway subnet"
-  type        = bool
+variable "private_endpoint_network_policies" {
+  default     = "Disabled"
+  description = "Enable or Disable network policies for the private endpoint on the subnet. Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled"
+  type        = string
 }
 
 variable "application_gateway_abbreviation" {

--- a/modules/azurerm/Application-Gateway/versions.tf
+++ b/modules/azurerm/Application-Gateway/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.94.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/azure_devops_custom_image_scale_set_agents.tf
+++ b/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/azure_devops_custom_image_scale_set_agents.tf
@@ -54,4 +54,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "scale_set_agent_linux_virtua
   identity {
     type = "SystemAssigned"
   }
+
+  scale_in {
+    force_deletion_enabled = var.force_deletion_enabled
+    rule                   = var.scale_in_rule
+  }
 }

--- a/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/subnet.tf
+++ b/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/subnet.tf
@@ -10,11 +10,12 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_subnet" "scale_set_agent_subnet" {
-  name                 = join("-", ["snet", var.subnet_name])
-  resource_group_name  = var.resource_group_name
-  virtual_network_name = var.virtual_network_name
-  address_prefixes     = var.subnet_address_prefixes
-  service_endpoints    = var.service_endpoints
+  name                              = join("-", ["snet", var.subnet_name])
+  resource_group_name               = var.resource_group_name
+  virtual_network_name              = var.virtual_network_name
+  address_prefixes                  = var.subnet_address_prefixes
+  service_endpoints                 = var.service_endpoints
+  private_endpoint_network_policies = var.private_endpoint_network_policies
 }
 
 resource "azurerm_network_security_group" "scale_set_agent_subnet_nsg" {

--- a/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/variables.tf
+++ b/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/variables.tf
@@ -127,3 +127,21 @@ variable "service_endpoints" {
   description = "The list of Service endpoints to associate with the subnet."
   type        = list(string)
 }
+
+variable "private_endpoint_network_policies" {
+  default     = "Disabled"
+  description = "Enable or Disable network policies for the private endpoint on the subnet. Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled"
+  type        = string
+}
+
+variable "force_deletion_enabled" {
+  default     = false
+  description = "Enable or disable force deletion of the virtual machine scale set instances"
+  type        = bool
+}
+
+variable "scale_in_rule" {
+  default     = "Default"
+  description = "The scale in rule for the virtual machine scale set"
+  type        = string
+}

--- a/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/versions.tf
+++ b/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.52.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/azurerm/Azure-Monitor-Private-Link-Scope/azure_monitor_private_link_scope.tf
+++ b/modules/azurerm/Azure-Monitor-Private-Link-Scope/azure_monitor_private_link_scope.tf
@@ -13,5 +13,6 @@ resource "azurerm_monitor_private_link_scope" "monitor_private_link_scope" {
   name                  = join("-", [var.monitor_private_link_scope_abbreviation, var.monitor_private_link_scope_name])
   resource_group_name   = var.resource_group_name
   ingestion_access_mode = var.ingestion_access_mode
+  query_access_mode     = var.query_access_mode
   tags                  = var.tags
 }

--- a/modules/azurerm/Azure-Monitor-Private-Link-Scope/variables.tf
+++ b/modules/azurerm/Azure-Monitor-Private-Link-Scope/variables.tf
@@ -35,3 +35,9 @@ variable "ingestion_access_mode" {
   type        = string
   default     = "PrivateOnly"
 }
+
+variable "query_access_mode" {
+  description = "The access mode for the Azure Monitor Private Link Scope"
+  type        = string
+  default     = "PrivateOnly"
+}

--- a/modules/azurerm/Bastion-Host/network.tf
+++ b/modules/azurerm/Bastion-Host/network.tf
@@ -10,11 +10,11 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_subnet" "bastion_host_subnet" {
-  name                                      = var.bastion_subnet_name
-  resource_group_name                       = var.resource_group_name
-  virtual_network_name                      = var.virtual_network_name
-  address_prefixes                          = [var.subnet_address_prefixes]
-  private_endpoint_network_policies_enabled = var.bastion_host_subnet_enforce_private_link_endpoint_network_policies
+  name                              = var.bastion_subnet_name
+  resource_group_name               = var.resource_group_name
+  virtual_network_name              = var.virtual_network_name
+  address_prefixes                  = [var.subnet_address_prefixes]
+  private_endpoint_network_policies = var.private_endpoint_network_policies
 }
 
 resource "azurerm_network_security_group" "bastion_host_nsg" {

--- a/modules/azurerm/Bastion-Host/variables.tf
+++ b/modules/azurerm/Bastion-Host/variables.tf
@@ -107,10 +107,10 @@ variable "allow_https_internet_inbound" {
   type        = bool
 }
 
-variable "bastion_host_subnet_enforce_private_link_endpoint_network_policies" {
-  default     = false
-  description = "Enable or Disable network policies for the private link endpoint on the bastion host subnet"
-  type        = bool
+variable "private_endpoint_network_policies" {
+  default     = "Disabled"
+  description = "Enable or Disable network policies for the private endpoint on the subnet. Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled"
+  type        = string
 }
 
 variable "bastion_host_abbreviation" {

--- a/modules/azurerm/Bastion-Host/versions.tf
+++ b/modules/azurerm/Bastion-Host/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/azurerm/Bastion-Internal/network.tf
+++ b/modules/azurerm/Bastion-Internal/network.tf
@@ -10,12 +10,12 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_subnet" "bastion_subnet" {
-  name                                      = join("-", [var.subnet_abbreviation, var.subnet_name])
-  resource_group_name                       = var.resource_group_name
-  virtual_network_name                      = var.virtual_network_name
-  address_prefixes                          = [var.subnet_address_prefix]
-  service_endpoints                         = ["Microsoft.Sql", "Microsoft.ContainerRegistry", "Microsoft.Storage"]
-  private_endpoint_network_policies_enabled = var.bastion_subnet_enforce_private_link_endpoint_network_policies
+  name                              = join("-", [var.subnet_abbreviation, var.subnet_name])
+  resource_group_name               = var.resource_group_name
+  virtual_network_name              = var.virtual_network_name
+  address_prefixes                  = [var.subnet_address_prefix]
+  service_endpoints                 = ["Microsoft.Sql", "Microsoft.ContainerRegistry", "Microsoft.Storage"]
+  private_endpoint_network_policies = var.private_endpoint_network_policies
 }
 
 resource "azurerm_route_table" "bastion_route_table" {

--- a/modules/azurerm/Bastion-Internal/storage_account.tf
+++ b/modules/azurerm/Bastion-Internal/storage_account.tf
@@ -10,18 +10,19 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_storage_account" "storage_account" {
-  name                            = join("", [var.storage_account_abbreviation, var.storage_account_name])
-  resource_group_name             = var.resource_group_name
-  location                        = var.location
-  account_tier                    = var.account_tier
-  access_tier                     = var.access_tier
-  account_replication_type        = var.account_replication_type
-  min_tls_version                 = "TLS1_2"
-  account_kind                    = "StorageV2"
-  enable_https_traffic_only       = true
-  allow_nested_items_to_be_public = var.allow_nested_items_to_be_public
-  public_network_access_enabled   = var.public_network_access_enabled
-  tags                            = var.tags
+  name                             = join("", [var.storage_account_abbreviation, var.storage_account_name])
+  resource_group_name              = var.resource_group_name
+  location                         = var.location
+  account_tier                     = var.account_tier
+  access_tier                      = var.access_tier
+  account_replication_type         = var.account_replication_type
+  min_tls_version                  = "TLS1_2"
+  account_kind                     = "StorageV2"
+  https_traffic_only_enabled       = true
+  allow_nested_items_to_be_public  = var.allow_nested_items_to_be_public
+  public_network_access_enabled    = var.public_network_access_enabled
+  cross_tenant_replication_enabled = var.cross_tenant_replication_enabled
+  tags                             = var.tags
 
   blob_properties {
 

--- a/modules/azurerm/Bastion-Internal/variables.tf
+++ b/modules/azurerm/Bastion-Internal/variables.tf
@@ -209,10 +209,10 @@ variable "private_dns_zone_ids" {
   type        = list(string)
 }
 
-variable "bastion_subnet_enforce_private_link_endpoint_network_policies" {
-  default     = false
-  description = "Enable or Disable network policies for the private link endpoint on the bastion subnet"
-  type        = bool
+variable "private_endpoint_network_policies" {
+  default     = "Disabled"
+  description = "Enable or Disable network policies for the private endpoint on the subnet. Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled"
+  type        = string
 }
 
 variable "managed_disk_abbreviation" {
@@ -297,4 +297,10 @@ variable "private_dns_zone_group_abbreviation" {
   description = "The abbreviation of the resource name."
   type        = string
   default     = "pvtdns"
+}
+
+variable "cross_tenant_replication_enabled" {
+  default     = false
+  description = "Enable or disable cross tenant replication"
+  type        = bool
 }

--- a/modules/azurerm/Bastion-Internal/versions.tf
+++ b/modules/azurerm/Bastion-Internal/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/azurerm/Firewall-Multiple-PIP/network.tf
+++ b/modules/azurerm/Firewall-Multiple-PIP/network.tf
@@ -10,9 +10,9 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_subnet" "firewall_subnet" {
-  name                                      = "AzureFirewallSubnet"
-  resource_group_name                       = var.resource_group_name
-  virtual_network_name                      = var.virtual_network_name
-  address_prefixes                          = [var.subnet_address_prefixes]
-  private_endpoint_network_policies_enabled = var.firewall_subnet_enforce_private_link_endpoint_network_policies
+  name                              = "AzureFirewallSubnet"
+  resource_group_name               = var.resource_group_name
+  virtual_network_name              = var.virtual_network_name
+  address_prefixes                  = [var.subnet_address_prefixes]
+  private_endpoint_network_policies = var.private_endpoint_network_policies
 }

--- a/modules/azurerm/Firewall-Multiple-PIP/variables.tf
+++ b/modules/azurerm/Firewall-Multiple-PIP/variables.tf
@@ -134,8 +134,8 @@ variable "application_rules" {
   }))
 }
 
-variable "firewall_subnet_enforce_private_link_endpoint_network_policies" {
-  default     = false
-  description = "Enable or Disable network policies for the private link endpoint on the firewall subnet"
-  type        = bool
+variable "private_endpoint_network_policies" {
+  default     = "Disabled"
+  description = "Enable or Disable network policies for the private endpoint on the subnet. Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled"
+  type        = string
 }

--- a/modules/azurerm/Firewall-Multiple-PIP/versions.tf
+++ b/modules/azurerm/Firewall-Multiple-PIP/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/monitor_activity_log_administrative_alerts.tf
+++ b/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/monitor_activity_log_administrative_alerts.tf
@@ -17,6 +17,7 @@ resource "azurerm_monitor_activity_log_alert" "monitor_activity_log_administrati
   scopes              = each.value.scopes
   description         = each.value.description
   enabled             = var.alert_enabled
+  location            = each.value.location
 
   criteria {
     resource_id    = each.value.resource_id

--- a/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/variables.tf
+++ b/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/variables.tf
@@ -28,13 +28,14 @@ variable "alert_enabled" {
 variable "activity_log_administrative_alerts" {
   description = "Map of azure activity log administrative alerts"
   type = map(object({
-    scopes                          = list(string)
-    monitor_activity_log_alert_name = string
-    description                     = string
-    monitor_action_group_id         = string
     category                        = string
+    description                     = string
+    location                        = string
+    monitor_action_group_id         = string
+    monitor_activity_log_alert_name = string
     operation_name                  = string
     resource_id                     = string
+    scopes                          = list(string)
   }))
 }
 

--- a/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/versions.tf
+++ b/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.52.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/azurerm/Monitor-Data-Collection-Rule/monitor_data_collection_rule.tf
+++ b/modules/azurerm/Monitor-Data-Collection-Rule/monitor_data_collection_rule.tf
@@ -41,6 +41,7 @@ resource "azurerm_monitor_data_collection_rule" "data_collection_rule" {
         name           = var.data_sources_syslog_name
         facility_names = var.data_sources_syslog_facility_names
         log_levels     = var.data_sources_syslog_log_levels
+        streams        = var.data_sources_syslog_streams
       }
     }
   }

--- a/modules/azurerm/Monitor-Data-Collection-Rule/variables.tf
+++ b/modules/azurerm/Monitor-Data-Collection-Rule/variables.tf
@@ -105,3 +105,9 @@ variable "stream_declaration_columns" {
     type = string
   }))
 }
+
+variable "data_sources_syslog_streams" {
+  default     = null
+  description = "Specifies a list of streams"
+  type        = list(string)
+}

--- a/modules/azurerm/Monitor-Data-Collection-Rule/versions.tf
+++ b/modules/azurerm/Monitor-Data-Collection-Rule/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.52.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/azurerm/Private-EndPoint-Subnet/private_endpoint_subnet.tf
+++ b/modules/azurerm/Private-EndPoint-Subnet/private_endpoint_subnet.tf
@@ -10,10 +10,10 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_subnet" "private_endpoint_subnet" {
-  name                                      = join("-", [var.private_endpoint_subnet_abbreviation, var.private_endpoint_subnet_name])
-  resource_group_name                       = var.resource_group_name
-  virtual_network_name                      = var.virtual_network_name
-  address_prefixes                          = [var.address_prefixes]
-  service_endpoints                         = ["Microsoft.Sql", "Microsoft.ContainerRegistry", "Microsoft.EventHub", "Microsoft.Storage"]
-  private_endpoint_network_policies_enabled = var.private_endpoint_subnet_enforce_private_link_endpoint_network_policies
+  name                              = join("-", [var.private_endpoint_subnet_abbreviation, var.private_endpoint_subnet_name])
+  resource_group_name               = var.resource_group_name
+  virtual_network_name              = var.virtual_network_name
+  address_prefixes                  = [var.address_prefixes]
+  service_endpoints                 = ["Microsoft.Sql", "Microsoft.ContainerRegistry", "Microsoft.EventHub", "Microsoft.Storage"]
+  private_endpoint_network_policies = var.private_endpoint_network_policies
 }

--- a/modules/azurerm/Private-EndPoint-Subnet/variables.tf
+++ b/modules/azurerm/Private-EndPoint-Subnet/variables.tf
@@ -49,10 +49,10 @@ variable "tags" {
   type        = map(string)
 }
 
-variable "private_endpoint_subnet_enforce_private_link_endpoint_network_policies" {
-  default     = false
-  description = "Enable or Disable network policies for the private link endpoint on the private endpoint subnet"
-  type        = bool
+variable "private_endpoint_network_policies" {
+  default     = "Disabled"
+  description = "Enable or Disable network policies for the private endpoint on the subnet. Possible values are Disabled, Enabled, NetworkSecurityGroupEnabled and RouteTableEnabled"
+  type        = string
 }
 
 variable "nsg_abbreviation" {

--- a/modules/azurerm/Private-EndPoint-Subnet/versions.tf
+++ b/modules/azurerm/Private-EndPoint-Subnet/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.52.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/azurerm/Storage-Account-File/storage_account_file.tf
+++ b/modules/azurerm/Storage-Account-File/storage_account_file.tf
@@ -10,16 +10,17 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_storage_account" "storage_account" {
-  name                            = join("", [var.storage_account_abbreviation, var.storage_account_name])
-  resource_group_name             = var.resource_group_name
-  location                        = var.location
-  account_tier                    = var.account_tier
-  account_replication_type        = var.account_replication_type
-  account_kind                    = "FileStorage"
-  enable_https_traffic_only       = true
-  min_tls_version                 = "TLS1_2"
-  allow_nested_items_to_be_public = var.allow_nested_items_to_be_public
-  tags                            = var.tags
+  name                             = join("", [var.storage_account_abbreviation, var.storage_account_name])
+  resource_group_name              = var.resource_group_name
+  location                         = var.location
+  account_tier                     = var.account_tier
+  account_replication_type         = var.account_replication_type
+  account_kind                     = "FileStorage"
+  https_traffic_only_enabled       = true
+  min_tls_version                  = "TLS1_2"
+  allow_nested_items_to_be_public  = var.allow_nested_items_to_be_public
+  cross_tenant_replication_enabled = var.cross_tenant_replication_enabled
+  tags                             = var.tags
 }
 
 resource "azurerm_advanced_threat_protection" "storage_account_advanced_threat_protection" {

--- a/modules/azurerm/Storage-Account-File/variables.tf
+++ b/modules/azurerm/Storage-Account-File/variables.tf
@@ -108,3 +108,9 @@ variable "storage_account_abbreviation" {
   type        = string
   default     = "st"
 }
+
+variable "cross_tenant_replication_enabled" {
+  default     = false
+  description = "Enable or disable cross tenant replication"
+  type        = bool
+}

--- a/modules/azurerm/Storage-Account-File/versions.tf
+++ b/modules/azurerm/Storage-Account-File/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0.0"
+      version = ">= 4.0.0"
     }
   }
 }

--- a/modules/azurerm/Storage-Account-Static-Website/storage_account_static_website.tf
+++ b/modules/azurerm/Storage-Account-Static-Website/storage_account_static_website.tf
@@ -10,19 +10,19 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_storage_account" "static_storage" {
-  name                            = join("", ["st", var.storage_account_name])
-  resource_group_name             = var.resource_group_name
-  location                        = var.location
-  account_kind                    = "StorageV2"
-  account_tier                    = var.account_tier
-  account_replication_type        = var.account_replication_type
-  min_tls_version                 = "TLS1_2"
-  enable_https_traffic_only       = true
-  allow_nested_items_to_be_public = var.allow_nested_items_to_be_public
-  tags                            = var.tags
+  name                             = join("", ["st", var.storage_account_name])
+  resource_group_name              = var.resource_group_name
+  location                         = var.location
+  account_kind                     = "StorageV2"
+  account_tier                     = var.account_tier
+  account_replication_type         = var.account_replication_type
+  min_tls_version                  = "TLS1_2"
+  https_traffic_only_enabled       = true
+  allow_nested_items_to_be_public  = var.allow_nested_items_to_be_public
+  cross_tenant_replication_enabled = var.cross_tenant_replication_enabled
+  tags                             = var.tags
 
   blob_properties {
-
     delete_retention_policy {
       days = 7
     }

--- a/modules/azurerm/Storage-Account-Static-Website/variables.tf
+++ b/modules/azurerm/Storage-Account-Static-Website/variables.tf
@@ -78,3 +78,9 @@ variable "network_rules_bypass" {
   description = "List of actions that bypass the network rule. Defaults to []"
   type        = list(string)
 }
+
+variable "cross_tenant_replication_enabled" {
+  default     = false
+  description = "Enable or disable cross tenant replication"
+  type        = bool
+}

--- a/modules/azurerm/Storage-Account-Static-Website/versions.tf
+++ b/modules/azurerm/Storage-Account-Static-Website/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.52.0"
+      version = ">= 4.0.0"
     }
   }
 }


### PR DESCRIPTION
## Purpose

Update a subset of AzureRM bundled modules to support AzureRM 4.x.x breaking changes. The following set of modules are updated with this PR

- AKS-Firewall
- AKS-Node-Pool
- Application-Gateway
- Azure-DevOps-Custom-Image-Scale-Set-Agents
- Azure-Monitor-Private-Link-Scope
- Bastion-Host
- Bastion-Internal
- Firewall-Multiple-PIP
- Monitor-Activity-Log-Administrative-Alerts
- Monitor-Data-Collection-Rule
- Private-EndPoint-Subnet
- Storage-Account-File
- Storage-Account-Static-Website