### PR TITLE
Modify Postgress-Flex-Server-conf module to support  dynamic PostgreS…

### DIFF
--- a/modules/azurerm/PostgreSQL-Flexible-Server-Configuration/postgresql_server.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server-Configuration/postgresql_server.tf
@@ -10,7 +10,8 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_postgresql_flexible_server_configuration" "server_configuration" {
-  name      = var.server_configuration_name
+  for_each  = var.server_configurations
+  name      = each.value.property
   server_id = var.postgresql_flexible_server_id
-  value     = var.sever_configuration_value
+  value     = each.value.settings
 }

--- a/modules/azurerm/PostgreSQL-Flexible-Server-Configuration/variables.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server-Configuration/variables.tf
@@ -8,18 +8,15 @@
 # You may not alter or remove any copyright or other notice from copies of this content.
 #
 # --------------------------------------------------------------------------------------
-
-variable "server_configuration_name" {
-  description = "Name of the PostgreSQL Server Configuration"
-  type        = string
+variable "server_configurations" {
+  description = "A map of PostgreSQL server configurations, where each entry contains a 'property' (parameter name) and 'settings' (parameter value)."
+  type = map(object({
+    property = string
+    settings = string
+  }))
+  default = {}
 }
-
-variable "sever_configuration_value" {
-  description = "Value of the PostgreSQL Server Configuration"
-  type        = string
-}
-
 variable "postgresql_flexible_server_id" {
-  description = "ID of the PostgreSQL Server"
+  description = "ID of the PostgreSQL Flexible Server."
   type        = string
 }


### PR DESCRIPTION
### Description ###
This pull request includes changes to the PostgreSQL Flexible Server Configuration module in the `azurerm` directory to enhance flexibility and update copyright information.

Enhancements to configuration flexibility:

* [`modules/azurerm/PostgreSQL-Flexible-Server-Configuration/postgresql_server.tf`](diffhunk://#diff-f1d36dc79d1759aafac6e29a7a362b169aa7abc67538542baf07134b23b965dcL13-R18): Modified the resource block to use `for_each` for iterating over server configurations, allowing multiple configurations to be defined.
* [`modules/azurerm/PostgreSQL-Flexible-Server-Configuration/variables.tf`](diffhunk://#diff-0f9b91596295f89677b589a6453a332e988a77f5f95ad4124dcc743a6abe6491L3-R21): Introduced a new variable `server_configurations` as a map of objects to replace individual configuration name and value variables, enabling more scalable configuration management.

Copyright update:

* [`modules/azurerm/PostgreSQL-Flexible-Server-Configuration/variables.tf`](diffhunk://#diff-0f9b91596295f89677b589a6453a332e988a77f5f95ad4124dcc743a6abe6491L3-R21): Updated the copyright year from 2023 to 2025.
