### PR TITLE
Add `source_application_security_group_ids` variable to Network Security Rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
+## [v2.4.0] - 2025-01-26
+
+### Added
+
+### Changed
+
+- Add `source_application_security_group_ids` variable to Network Security Rule
+
+### Fixed
+
 ## [v2.3.0] - 2025-01-22
 
 ### Added

--- a/modules/azurerm/Network-Security-Rule/network_security_rule.tf
+++ b/modules/azurerm/Network-Security-Rule/network_security_rule.tf
@@ -10,19 +10,20 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_network_security_rule" "network_security_rule" {
-  name                         = var.network_security_rule_name
-  priority                     = var.priority
-  direction                    = var.direction
-  access                       = var.access
-  protocol                     = var.protocol
-  source_port_range            = var.source_port_range
-  destination_port_range       = var.destination_port_range
-  source_port_ranges           = var.source_port_ranges
-  destination_port_ranges      = var.destination_port_ranges
-  source_address_prefix        = var.source_address_prefix
-  destination_address_prefix   = var.destination_address_prefix
-  source_address_prefixes      = var.source_address_prefixes
-  destination_address_prefixes = var.destination_address_prefixes
-  resource_group_name          = var.resource_group_name
-  network_security_group_name  = var.nsg_name
+  name                                  = var.network_security_rule_name
+  priority                              = var.priority
+  direction                             = var.direction
+  access                                = var.access
+  protocol                              = var.protocol
+  source_port_range                     = var.source_port_range
+  destination_port_range                = var.destination_port_range
+  source_port_ranges                    = var.source_port_ranges
+  destination_port_ranges               = var.destination_port_ranges
+  source_address_prefix                 = var.source_address_prefix
+  destination_address_prefix            = var.destination_address_prefix
+  source_address_prefixes               = var.source_address_prefixes
+  destination_address_prefixes          = var.destination_address_prefixes
+  resource_group_name                   = var.resource_group_name
+  network_security_group_name           = var.nsg_name
+  source_application_security_group_ids = var.source_application_security_group_ids
 }

--- a/modules/azurerm/Network-Security-Rule/variables.tf
+++ b/modules/azurerm/Network-Security-Rule/variables.tf
@@ -91,3 +91,9 @@ variable "source_address_prefixes" {
   description = "List source address range for considered traffic"
   type        = list(string)
 }
+
+variable "source_application_security_group_ids" {
+  default     = null
+  description = "List of source application security group ids"
+  type        = list(string)
+}


### PR DESCRIPTION
### Purpose

This pull request includes changes to the Azure Network Security Rule module to support source application security group IDs. The most important changes are as follows:

Enhancements to Network Security Rule:

* [`modules/azurerm/Network-Security-Rule/network_security_rule.tf`](diffhunk://#diff-c07ac192dfb5e73517f636a5b4ff845ab37874b78ad3d3c4ae7c2dc5f68fdb2aR28): Added support for `source_application_security_group_ids` by including the new variable in the resource definition.

New variable definition:

* [`modules/azurerm/Network-Security-Rule/variables.tf`](diffhunk://#diff-1bb695f066064cde4dee8dde4bbad9f547232120d317fa47532ce762ee4b3218R94-R99): Introduced a new variable `source_application_security_group_ids` with a description and type definition.