### PR TITLE
Add Firewall Public IP Association Output & App Configuration Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
+## [v2.6.0] - 2025-02-06
+
+### Added
+
+- Add Firewall Public IP Association Output & App Configuration Modules 
+
+### Changed
+
+### Fixed
+
 ## [v2.5.0] - 2025-01-28
 
 ### Added

--- a/modules/azurerm/AKS-Generic/aks_cluster.tf
+++ b/modules/azurerm/AKS-Generic/aks_cluster.tf
@@ -34,6 +34,10 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
     }
   }
 
+  api_server_access_profile {
+    authorized_ip_ranges = var.api_server_authorized_ip_ranges
+  }
+
   default_node_pool {
     name                         = join("", ["aksnp", var.default_node_pool_name])
     node_count                   = var.default_node_pool_count
@@ -79,6 +83,7 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
       windows_profile,
       kubernetes_version,
       default_node_pool[0].orchestrator_version,
+      api_server_access_profile
     ]
   }
 }

--- a/modules/azurerm/AKS-Generic/variables.tf
+++ b/modules/azurerm/AKS-Generic/variables.tf
@@ -299,3 +299,8 @@ variable "internal_load_balancer_subnet_enforce_private_link_endpoint_network_po
   description = "Enable or Disable network policies for the private link endpoint on the internal load balancer subnet"
   type        = string
 }
+
+variable "api_server_authorized_ip_ranges" {
+  description = "List of authorized IP ranges for the Kubernetes API server"
+  type        = list(string)
+}

--- a/modules/azurerm/App-Configuration-Key/app_configuration_key.tf
+++ b/modules/azurerm/App-Configuration-Key/app_configuration_key.tf
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_app_configuration_key" "app_configuration_key" {
+  for_each               = var.configuration_keys
+  configuration_store_id = var.app_configuration_store_id
+  key                    = each.value.key
+  label                  = each.value.label
+  content_type           = each.value.content_type
+  value                  = each.value.value
+  locked                 = each.value.locked
+  type                   = each.value.type
+  tags                   = each.value.tags
+}

--- a/modules/azurerm/App-Configuration-Key/variables.tf
+++ b/modules/azurerm/App-Configuration-Key/variables.tf
@@ -1,0 +1,38 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "app_configuration_store_id" {
+  description = "The ID of the App Configuration."
+  type        = string
+}
+
+variable "configuration_keys" {
+  description = "A list of configuration keys for the App Configuration."
+  type = map(object({
+    key          = string
+    label        = string
+    content_type = string
+    value        = string
+    locked       = bool
+    type         = string
+    tags         = map(string)
+  }))
+  default = {}
+}

--- a/modules/azurerm/App-Configuration-Key/versions.tf
+++ b/modules/azurerm/App-Configuration-Key/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0.0"
+    }
+  }
+}

--- a/modules/azurerm/App-Configuration/app_configuration.tf
+++ b/modules/azurerm/App-Configuration/app_configuration.tf
@@ -1,0 +1,39 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_app_configuration" "app_configuration" {
+  name                       = join("-", [var.app_configuration_abbreviation, var.app_configuration_name])
+  resource_group_name        = var.resource_group_name
+  location                   = var.location
+  local_auth_enabled         = var.local_auth_enabled
+  public_network_access      = var.public_network_access
+  purge_protection_enabled   = var.purge_protection_enabled
+  sku                        = var.sku
+  soft_delete_retention_days = var.soft_delete_retention_days
+  tags                       = var.tags
+
+  dynamic "replica" {
+    for_each = var.replicas
+    content {
+      name     = replica.value.name
+      location = replica.value.location
+    }
+  }
+}

--- a/modules/azurerm/App-Configuration/app_configuration_key.tf
+++ b/modules/azurerm/App-Configuration/app_configuration_key.tf
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_app_configuration_key" "app_configuration_key" {
+  for_each               = var.configuration_keys
+  configuration_store_id = azurerm_app_configuration.app_configuration.id
+  key                    = each.value.key
+  label                  = each.value.label
+  content_type           = each.value.content_type
+  value                  = each.value.value
+  locked                 = each.value.locked
+  type                   = each.value.type
+  tags                   = each.value.tags
+}

--- a/modules/azurerm/App-Configuration/outputs.tf
+++ b/modules/azurerm/App-Configuration/outputs.tf
@@ -1,0 +1,34 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "id" {
+  description = "The ID of the App Configuration."
+  value       = azurerm_app_configuration.app_configuration.id
+}
+
+output "name" {
+  description = "The name of the App Configuration."
+  value       = azurerm_app_configuration.app_configuration.name
+}
+
+output "endpoint" {
+  description = "The endpoint of the App Configuration."
+  value       = azurerm_app_configuration.app_configuration.endpoint
+}

--- a/modules/azurerm/App-Configuration/variables.tf
+++ b/modules/azurerm/App-Configuration/variables.tf
@@ -1,0 +1,99 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "app_configuration_abbreviation" {
+  description = "The abbreviation of the App Configuration."
+  type        = string
+  default     = "appconfig"
+}
+
+variable "app_configuration_name" {
+  description = "The name of the App Configuration."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group in which the App Configuration should be created."
+  type        = string
+}
+
+variable "location" {
+  description = "The location/region where the App Configuration should be created."
+  type        = string
+}
+
+variable "local_auth_enabled" {
+  description = "Is local authentication enabled for the App Configuration."
+  type        = bool
+  default     = false
+}
+
+variable "public_network_access" {
+  description = "The public network access for the App Configuration."
+  type        = string
+  default     = "Enabled"
+}
+
+variable "purge_protection_enabled" {
+  description = "Is purge protection enabled for the App Configuration."
+  type        = bool
+  default     = false
+}
+
+variable "sku" {
+  description = "The SKU of the App Configuration."
+  type        = string
+  default     = "free"
+}
+
+variable "soft_delete_retention_days" {
+  description = "The number of days to retain deleted configuration values."
+  type        = number
+  default     = 7
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to the resource."
+  type        = map(string)
+  default     = {}
+}
+
+variable "replicas" {
+  description = "A list of replicas for the App Configuration."
+  type = list(object({
+    name     = string
+    location = string
+  }))
+  default = []
+}
+
+variable "configuration_keys" {
+  description = "A list of configuration keys for the App Configuration."
+  type = map(object({
+    key          = string
+    label        = string
+    content_type = string
+    value        = string
+    locked       = bool
+    type         = string
+    tags         = map(string)
+  }))
+  default = {}
+}

--- a/modules/azurerm/App-Configuration/versions.tf
+++ b/modules/azurerm/App-Configuration/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0.0"
+    }
+  }
+}

--- a/modules/azurerm/Firewall/output.tf
+++ b/modules/azurerm/Firewall/output.tf
@@ -38,3 +38,8 @@ output "firewall_public_ip_names" {
   value      = [for pip in azurerm_public_ip.firewall_public_ip : pip.name]
   depends_on = [azurerm_public_ip.firewall_public_ip]
 }
+
+output "firewall_public_ip_associations" {
+  value      = {for pip in azurerm_public_ip.firewall_public_ip : pip.name => pip.ip_address}
+  depends_on = [azurerm_public_ip.firewall_public_ip]
+}


### PR DESCRIPTION
## Purpose

This pull request introduces several new Terraform resources and variables for managing Azure App Configuration and its keys. The changes include adding new resource definitions, variables, and outputs across multiple files.

Key changes:

### New Resource Definitions:
* Added `azurerm_app_configuration` resource in `app_configuration.tf` to manage Azure App Configuration instances.
* Added `azurerm_app_configuration_key` resource in `app_configuration_key.tf` and `app_configuration_key.tf` to manage configuration keys for App Configuration. [[1]](diffhunk://#diff-73f178dc20764ba8731a5bcf0667e2e7788cbc14964d65f26be7fc7a83a8b741R1-R31) [[2]](diffhunk://#diff-0aea3a55aaaeddd1bb4306b59e0f736af6da9fc3c425bc036c1e58d5c58f07bfR1-R31)

### Variable Definitions:
* Defined multiple new variables in `variables.tf` to support the new resources, including `app_configuration_store_id`, `configuration_keys`, `app_configuration_abbreviation`, `app_configuration_name`, `resource_group_name`, `location`, `local_auth_enabled`, `public_network_access`, `purge_protection_enabled`, `sku`, `soft_delete_retention_days`, `tags`, and `replicas`. [[1]](diffhunk://#diff-6ca7657a79fd7915296b598628a14d5a1bd227d905b271ae2ccaeda9f9acf544R1-R38) [[2]](diffhunk://#diff-09d57bb6757bc4a04cfd4a6138257c5bf56fcf7e550a9c085ae0af693f7366acR1-R99)

### Outputs:
* Added outputs in `outputs.tf` to expose the ID, name, and endpoint of the App Configuration.

### Terraform Configuration:
* Updated `versions.tf` to specify required Terraform and provider versions.

### Additional Output:
* Added a new output `firewall_public_ip_associations` in `output.tf` to map firewall public IP names to their IP addresses.