### PR TITLE
Add support for Trusted Launch in Shared Image module

### DIFF
--- a/modules/azurerm/Compute-Image/compute_image.tf
+++ b/modules/azurerm/Compute-Image/compute_image.tf
@@ -10,12 +10,14 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_shared_image" "compute_image" {
-  name                = join("-", [var.shared_image_abbreviation, var.name])
-  gallery_name        = var.gallery_name
-  resource_group_name = var.resource_group
-  location            = var.location
-  os_type             = var.shared_image_os_type
-  hyper_v_generation  = var.hyper_v_generation
+  name                     = join("-", [var.shared_image_abbreviation, var.name])
+  gallery_name             = var.gallery_name
+  resource_group_name      = var.resource_group
+  location                 = var.location
+  os_type                  = var.shared_image_os_type
+  hyper_v_generation       = var.hyper_v_generation
+  trusted_launch_supported = var.trusted_launch_supported
+  trusted_launch_enabled   = var.trusted_launch_enabled
 
   identifier {
     publisher = var.shared_image_publisher

--- a/modules/azurerm/Compute-Image/variables.tf
+++ b/modules/azurerm/Compute-Image/variables.tf
@@ -64,3 +64,15 @@ variable "shared_image_abbreviation" {
   type        = string
   default     = "si"
 }
+
+variable "trusted_launch_supported" {
+  description = "Specifies whether Trusted Launch is supported for the Shared Image."
+  type        = bool
+  default     = null
+}
+
+variable "trusted_launch_enabled" {
+  description = "Specifies whether Trusted Launch is enabled for the Shared Image."
+  type        = bool
+  default     = null
+}

--- a/modules/azurerm/Firewall/output.tf
+++ b/modules/azurerm/Firewall/output.tf
@@ -40,6 +40,6 @@ output "firewall_public_ip_names" {
 }
 
 output "firewall_public_ip_associations" {
-  value      = {for pip in azurerm_public_ip.firewall_public_ip : pip.name => pip.ip_address}
+  value      = { for pip in azurerm_public_ip.firewall_public_ip : pip.name => pip.ip_address }
   depends_on = [azurerm_public_ip.firewall_public_ip]
 }

--- a/modules/azurerm/Storage-Account-Static-Website-CDN/outputs.tf
+++ b/modules/azurerm/Storage-Account-Static-Website-CDN/outputs.tf
@@ -45,20 +45,20 @@ output "storage_account_secondary_web_endpoint" {
 
 output "cdn_profile_name" {
   depends_on = [azurerm_cdn_profile.cdn_profile]
-  value = azurerm_cdn_profile.cdn_profile.name
+  value      = azurerm_cdn_profile.cdn_profile.name
 }
 
 output "cdn_profile_id" {
   depends_on = [azurerm_cdn_profile.cdn_profile]
-  value = azurerm_cdn_profile.cdn_profile.id
+  value      = azurerm_cdn_profile.cdn_profile.id
 }
 
 output "cdn_endpoint_fqdn" {
   depends_on = [azurerm_cdn_endpoint.cdn_endpoint]
-  value = azurerm_cdn_endpoint.cdn_endpoint.fqdn
+  value      = azurerm_cdn_endpoint.cdn_endpoint.fqdn
 }
 
 output "cdn_endpoint_id" {
   depends_on = [azurerm_cdn_endpoint.cdn_endpoint]
-  value = azurerm_cdn_endpoint.cdn_endpoint.id
+  value      = azurerm_cdn_endpoint.cdn_endpoint.id
 }


### PR DESCRIPTION
## Description

This pull request introduces support for Trusted Launch in the Azure Resource Manager (ARM) shared image module. The changes include updating the `compute_image.tf` and `variables.tf` files to incorporate new variables and properties related to Trusted Launch.

### Support for Trusted Launch:

* [`modules/azurerm/Compute-Image/compute_image.tf`](diffhunk://#diff-f3891b761fbead5d98493d9c8c728386be9fc287b3de084bd4d105dd371caebfR19-R20): Added `trusted_launch_supported` and `trusted_launch_enabled` properties to the `azurerm_shared_image` resource.
* [`modules/azurerm/Compute-Image/variables.tf`](diffhunk://#diff-b79765295b7ba6f3944d4a26e4319676deeb4d225323dba1c155e0f4d218d2f2R67-R78): Introduced new variables `trusted_launch_supported` and `trusted_launch_enabled` with descriptions and default values.