### PR TITLE
Update the cache_duration type from number to string

### DIFF
--- a/modules/azurerm/CDN-FrontDoor-Rule-Set/variables.tf
+++ b/modules/azurerm/CDN-FrontDoor-Rule-Set/variables.tf
@@ -50,7 +50,7 @@ variable "rules" {
     }))
 
     route_configuration_override_actions = list(object({
-      cache_duration                = number
+      cache_duration                = string
       cdn_frontdoor_origin_group_id = string
       forwarding_protocol           = string
       query_string_caching_behavior = string


### PR DESCRIPTION
## Purpose
> Update the cache_duration type from number to string

## Reason
> According to [this documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule#cache_duration-1), cache_duration should be in the format `d.HH:MM:SS` or `HH:MM:SS`.