### PR TITLE
Onboarding  Private-DNS-Zone-Vnet-Link for azapi and Group-Membership & Service-Principal-Entitlement for azuredevops

### DIFF
--- a/modules/azapi/Private-DNS-Zone-Vnet-Link/private_dns_zone_vnet_link.tf
+++ b/modules/azapi/Private-DNS-Zone-Vnet-Link/private_dns_zone_vnet_link.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,19 @@
 #
 # --------------------------------------------------------------------------------------
 
-output "elastic_pool_id" {
-  description = "The ID of the elastic pool."
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.id
-}
+resource "azapi_resource" "private_dns_zone_vnet_link" {
+  type      = "Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01"
+  parent_id = var.private_dns_zone_id
+  name      = var.private_dns_zone_vnet_link_name
+  location  = "global"
 
-output "elastic_pool_name" {
-  description = "The Name of the elastic pool"
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.name
+  body = {
+    properties = {
+      registrationEnabled = var.registration_enabled
+      resolutionPolicy    = var.dns_resolution_policy
+      virtualNetwork = {
+        id = var.virtual_network_id
+      }
+    }
+  }
 }

--- a/modules/azapi/Private-DNS-Zone-Vnet-Link/variables.tf
+++ b/modules/azapi/Private-DNS-Zone-Vnet-Link/variables.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,27 @@
 #
 # --------------------------------------------------------------------------------------
 
-output "elastic_pool_id" {
-  description = "The ID of the elastic pool."
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.id
+variable "private_dns_zone_id" {
+  type        = string
+  description = "Existing Private DNS Zone resource ID"
 }
 
-output "elastic_pool_name" {
-  description = "The Name of the elastic pool"
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.name
+variable "private_dns_zone_vnet_link_name" {
+  type        = string
+  description = "VNet Link name for the Private DNS Zone"
+}
+
+variable "virtual_network_id" {
+  type        = string
+  description = "Existing Virtual Network ID"
+}
+
+variable "registration_enabled" {
+  type        = bool
+  description = "Enable automatic registration of virtual network in the Private DNS Zone"
+}
+
+variable "dns_resolution_policy" {
+  type        = string
+  description = "DNS resolution policy for the Private DNS Zone"
 }

--- a/modules/azapi/Private-DNS-Zone-Vnet-Link/variables.tf
+++ b/modules/azapi/Private-DNS-Zone-Vnet-Link/variables.tf
@@ -19,26 +19,26 @@
 # --------------------------------------------------------------------------------------
 
 variable "private_dns_zone_id" {
-  type        = string
   description = "Existing Private DNS Zone resource ID"
+  type        = string
 }
 
 variable "private_dns_zone_vnet_link_name" {
-  type        = string
   description = "VNet Link name for the Private DNS Zone"
+  type        = string
 }
 
 variable "virtual_network_id" {
-  type        = string
   description = "Existing Virtual Network ID"
+  type        = string
 }
 
 variable "registration_enabled" {
+  description = "Existing Virtual Network ID"
   type        = bool
-  description = "Enable automatic registration of virtual network in the Private DNS Zone"
 }
 
 variable "dns_resolution_policy" {
+  description = "DNS resolution policy for the Private DNS Zone.This value can be 'Default' or 'NxDomainRedirect'"
   type        = string
-  description = "DNS resolution policy for the Private DNS Zone"
 }

--- a/modules/azapi/Private-DNS-Zone-Vnet-Link/variables.tf
+++ b/modules/azapi/Private-DNS-Zone-Vnet-Link/variables.tf
@@ -34,7 +34,7 @@ variable "virtual_network_id" {
 }
 
 variable "registration_enabled" {
-  description = "Existing Virtual Network ID"
+  description = "Enable automatic registration of virtual network in the Private DNS Zone"
   type        = bool
 }
 

--- a/modules/azapi/Private-DNS-Zone-Vnet-Link/variables.tf
+++ b/modules/azapi/Private-DNS-Zone-Vnet-Link/variables.tf
@@ -39,6 +39,7 @@ variable "registration_enabled" {
 }
 
 variable "dns_resolution_policy" {
-  description = "DNS resolution policy for the Private DNS Zone.This value can be 'Default' or 'NxDomainRedirect'"
+  default = "Default"
+  description = "DNS resolution policy for the Private DNS Zone. This value can be 'Default' or 'NxDomainRedirect'"
   type        = string
 }

--- a/modules/azapi/Private-DNS-Zone-Vnet-Link/variables.tf
+++ b/modules/azapi/Private-DNS-Zone-Vnet-Link/variables.tf
@@ -39,7 +39,7 @@ variable "registration_enabled" {
 }
 
 variable "dns_resolution_policy" {
-  default = "Default"
   description = "DNS resolution policy for the Private DNS Zone. This value can be 'Default' or 'NxDomainRedirect'"
   type        = string
+  default     = "Default"
 }

--- a/modules/azapi/Private-DNS-Zone-Vnet-Link/versions.tf
+++ b/modules/azapi/Private-DNS-Zone-Vnet-Link/versions.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,12 @@
 #
 # --------------------------------------------------------------------------------------
 
-output "elastic_pool_id" {
-  description = "The ID of the elastic pool."
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.id
-}
-
-output "elastic_pool_name" {
-  description = "The Name of the elastic pool"
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.name
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = ">= 1.12.1"
+    }
+  }
 }

--- a/modules/azuredevops/Group-Membership/group_membership.tf
+++ b/modules/azuredevops/Group-Membership/group_membership.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,7 @@
 #
 # --------------------------------------------------------------------------------------
 
-output "elastic_pool_id" {
-  description = "The ID of the elastic pool."
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.id
-}
-
-output "elastic_pool_name" {
-  description = "The Name of the elastic pool"
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.name
+resource "azuredevops_group_membership" "group_membership" {
+  group   = var.group_descriptor
+  members = var.member_descriptors
 }

--- a/modules/azuredevops/Group-Membership/variables.tf
+++ b/modules/azuredevops/Group-Membership/variables.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,12 @@
 #
 # --------------------------------------------------------------------------------------
 
-output "elastic_pool_id" {
-  description = "The ID of the elastic pool."
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.id
+variable "group_descriptor" {
+  description = "The descriptor of the group to add members to"
+  type        = string
 }
 
-output "elastic_pool_name" {
-  description = "The Name of the elastic pool"
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.name
+variable "member_descriptors" {
+  description = "The descriptors of the members to add to the group"
+  type        = list(string)
 }

--- a/modules/azuredevops/Group-Membership/versions.tf
+++ b/modules/azuredevops/Group-Membership/versions.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,12 @@
 #
 # --------------------------------------------------------------------------------------
 
-output "elastic_pool_id" {
-  description = "The ID of the elastic pool."
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.id
-}
-
-output "elastic_pool_name" {
-  description = "The Name of the elastic pool"
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.name
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azuredevops = {
+      source  = "microsoft/azuredevops"
+      version = ">= 0.7.0"
+    }
+  }
 }

--- a/modules/azuredevops/Service-Principal-Entitlement/outputs.tf
+++ b/modules/azuredevops/Service-Principal-Entitlement/outputs.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,8 @@
 #
 # --------------------------------------------------------------------------------------
 
-output "elastic_pool_id" {
-  description = "The ID of the elastic pool."
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.id
-}
-
-output "elastic_pool_name" {
-  description = "The Name of the elastic pool"
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.name
+output "descriptor" {
+  description = "The Descriptor of the service principal entitlement."
+  depends_on  = [azuredevops_service_principal_entitlement.service_principal_entitlement]
+  value       = azuredevops_service_principal_entitlement.service_principal_entitlement.descriptor
 }

--- a/modules/azuredevops/Service-Principal-Entitlement/service_principal_entitlement.tf
+++ b/modules/azuredevops/Service-Principal-Entitlement/service_principal_entitlement.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,6 @@
 #
 # --------------------------------------------------------------------------------------
 
-output "elastic_pool_id" {
-  description = "The ID of the elastic pool."
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.id
-}
-
-output "elastic_pool_name" {
-  description = "The Name of the elastic pool"
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.name
+resource "azuredevops_service_principal_entitlement" "service_principal_entitlement" {
+  origin_id = var.sp_object_id
 }

--- a/modules/azuredevops/Service-Principal-Entitlement/variables.tf
+++ b/modules/azuredevops/Service-Principal-Entitlement/variables.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,7 @@
 #
 # --------------------------------------------------------------------------------------
 
-output "elastic_pool_id" {
-  description = "The ID of the elastic pool."
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.id
-}
-
-output "elastic_pool_name" {
-  description = "The Name of the elastic pool"
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.name
+variable "sp_object_id" {
+  description = "The object ID of the service principal"
+  type        = string
 }

--- a/modules/azuredevops/Service-Principal-Entitlement/versions.tf
+++ b/modules/azuredevops/Service-Principal-Entitlement/versions.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,12 @@
 #
 # --------------------------------------------------------------------------------------
 
-output "elastic_pool_id" {
-  description = "The ID of the elastic pool."
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.id
-}
-
-output "elastic_pool_name" {
-  description = "The Name of the elastic pool"
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.name
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azuredevops = {
+      source  = "microsoft/azuredevops"
+      version = ">= 1.6.0"
+    }
+  }
 }

--- a/modules/azuredevops/Workload-Identity-Federation-Automatic-ARM-Service-Endpoint/devops_serviceendpoint.tf
+++ b/modules/azuredevops/Workload-Identity-Federation-Automatic-ARM-Service-Endpoint/devops_serviceendpoint.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,12 @@
 #
 # --------------------------------------------------------------------------------------
 
-output "elastic_pool_id" {
-  description = "The ID of the elastic pool."
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.id
-}
-
-output "elastic_pool_name" {
-  description = "The Name of the elastic pool"
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.name
+resource "azuredevops_serviceendpoint_azurerm" "devops_serviceendpoint_azurerm" {
+  project_id                             = var.project_id
+  service_endpoint_name                  = var.service_endpoint_name
+  azurerm_spn_tenantid                   = var.tenant_id
+  azurerm_subscription_id                = var.subscription_id
+  azurerm_subscription_name              = var.subscription_name
+  description                            = var.description
+  service_endpoint_authentication_scheme = "WorkloadIdentityFederation"
 }

--- a/modules/azuredevops/Workload-Identity-Federation-Automatic-ARM-Service-Endpoint/outputs.tf
+++ b/modules/azuredevops/Workload-Identity-Federation-Automatic-ARM-Service-Endpoint/outputs.tf
@@ -1,0 +1,44 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "serviceendpoint_id" {
+  depends_on = [azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm]
+  value      = azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm.id
+}
+
+output "serviceendpoint_name" {
+  depends_on = [azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm]
+  value      = azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm.service_endpoint_name
+}
+
+output "service_principal_id" {
+  depends_on = [azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm]
+  value      = azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm.service_principal_id
+}
+
+output "workload_identity_federation_issuer" {
+  depends_on = [azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm]
+  value      = azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm.workload_identity_federation_issuer
+}
+
+output "workload_identity_federation_subject" {
+  depends_on = [azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm]
+  value      = azuredevops_serviceendpoint_azurerm.devops_serviceendpoint_azurerm.workload_identity_federation_subject
+}

--- a/modules/azuredevops/Workload-Identity-Federation-Automatic-ARM-Service-Endpoint/variables.tf
+++ b/modules/azuredevops/Workload-Identity-Federation-Automatic-ARM-Service-Endpoint/variables.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,14 +18,32 @@
 #
 # --------------------------------------------------------------------------------------
 
-output "elastic_pool_id" {
-  description = "The ID of the elastic pool."
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.id
+variable "service_endpoint_name" {
+  description = "The name of the service endpoint."
+  type        = string
 }
 
-output "elastic_pool_name" {
-  description = "The Name of the elastic pool"
-  depends_on  = [azuredevops_elastic_pool.elastic_pool]
-  value       = azuredevops_elastic_pool.elastic_pool.name
+variable "project_id" {
+  description = "The ID of the project."
+  type        = string
+}
+
+variable "description" {
+  description = "The description of the service endpoint."
+  type        = string
+}
+
+variable "tenant_id" {
+  description = "The Tenant ID if the service principal."
+  type        = string
+}
+
+variable "subscription_id" {
+  description = "The Subscription ID of the Azure targets."
+  type        = string
+}
+
+variable "subscription_name" {
+  description = "The Subscription Name of the targets."
+  type        = string
 }

--- a/modules/azuredevops/Workload-Identity-Federation-Automatic-ARM-Service-Endpoint/versions.tf
+++ b/modules/azuredevops/Workload-Identity-Federation-Automatic-ARM-Service-Endpoint/versions.tf
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azuredevops = {
+      source  = "microsoft/azuredevops"
+      version = ">= 0.7.0"
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
This PR introduces a set of new modules for azapi and azuredevops providers
- `Private-DNS-Zone-Vnet-Link` (azapi) - This experimental vnet link module has some newer features introduced by azure for dns resolution within private dns zones.
- `Group-Membership` (azuredevops) - This module can be used to add existing users or service principals to a group within an azure devops organization
- `Service-Principal-Entitlement` (azuredevops) - This module can be used to enroll a service principal as an user within a azure devops organization

## Other Enhancements
- Introduce a new output called `elastic_pool_name` for the Elastic-Pool (azuredevops) module
