### PR TITLE
Add Cosmos DB Primary Access Key to the Module output

### DIFF
--- a/modules/azurerm/Cosmos-Database-Account/outputs.tf
+++ b/modules/azurerm/Cosmos-Database-Account/outputs.tf
@@ -38,3 +38,8 @@ output "cosmos_db_account_name" {
   depends_on = [azurerm_cosmosdb_account.cosmos_db_account]
   value      = azurerm_cosmosdb_account.cosmos_db_account.name
 }
+
+output "cosmos_db_account_primary_key" {
+  depends_on = [azurerm_cosmosdb_account.cosmos_db_account]
+  value      = azurerm_cosmosdb_account.cosmos_db_account.primary_key
+}


### PR DESCRIPTION
## Description
Added output cosmos_db_account_primary_key to retrieve the Cosmos DB Primary Access Key from the azurerm_cosmosdb_account resource.