### PR TITLE
Remove `kubernetes_version` from `ignore_changes` in AKS cluster lifecycle

### DIFF
--- a/modules/azurerm/AKS-Firewall/aks_cluster.tf
+++ b/modules/azurerm/AKS-Firewall/aks_cluster.tf
@@ -34,7 +34,6 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
     ignore_changes = [
       default_node_pool[0].node_count,
       windows_profile,
-      kubernetes_version,
       default_node_pool[0].orchestrator_version,
       microsoft_defender,
       api_server_access_profile


### PR DESCRIPTION
## Description

This pull request includes a small change to the `aks_cluster.tf` file. The change removes `kubernetes_version` from the `ignore_changes` list in the `azurerm_kubernetes_cluster` resource, ensuring that updates to this field will now be tracked and applied.