### PR TITLE
Remove `orchestrator_version` from `ignore_changes` in AKS Node Pool

### DIFF
--- a/modules/azurerm/AKS-Node-Pool/aks_node_pool.tf
+++ b/modules/azurerm/AKS-Node-Pool/aks_node_pool.tf
@@ -36,8 +36,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "kubernetes_cluster_node_pool" {
 
   lifecycle {
     ignore_changes = [
-      node_count,
-      orchestrator_version,
+      node_count
     ]
   }
 }


### PR DESCRIPTION
### Description

This pull request modifies the lifecycle configuration of the `azurerm_kubernetes_cluster_node_pool` resource to adjust which properties are ignored during updates.

### Changes to lifecycle configuration:

* [`modules/azurerm/AKS-Node-Pool/aks_node_pool.tf`](diffhunk://#diff-74ffde4ad1505b7f56474d8b6896f8f12fffb97580ddfefe22b85abe83e49b42L39-R39): Removed `orchestrator_version` from the `ignore_changes` list, leaving only `node_count`. This ensures that changes to the `orchestrator_version` property will now trigger updates to the resource.