### PR TITLE
Add express vulnerability assessment support for MsSQL Server

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Security Scan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: read

--- a/modules/azurerm/MsSQL-Database/mssql_database.tf
+++ b/modules/azurerm/MsSQL-Database/mssql_database.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
 #
 # This software is the property of WSO2 LLC. and its suppliers, if any.
 # Dissemination of any information or reproduction of any material contained

--- a/modules/azurerm/MsSQL-Database/mssql_database.tf
+++ b/modules/azurerm/MsSQL-Database/mssql_database.tf
@@ -29,5 +29,8 @@ resource "azurerm_mssql_database" "mssql_database" {
 
   lifecycle {
     prevent_destroy = true
+    ignore_changes = [
+      auto_pause_delay_in_minutes
+    ]
   }
 }

--- a/modules/azurerm/MsSQL-Server/mssql_server.tf
+++ b/modules/azurerm/MsSQL-Server/mssql_server.tf
@@ -10,15 +10,16 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_mssql_server" "mssql_server" {
-  name                          = join("-", [var.mssql_server_abbreviation, var.mssql_server_name])
-  resource_group_name           = var.resource_group_name
-  location                      = var.location
-  version                       = var.db_server_version
-  administrator_login           = var.db_server_administrator_login
-  administrator_login_password  = var.db_server_administrator_login_password
-  minimum_tls_version           = var.db_server_minimum_tls_version
-  public_network_access_enabled = var.db_server_public_network_access_enabled
-  tags                          = var.tags
+  name                                     = join("-", [var.mssql_server_abbreviation, var.mssql_server_name])
+  resource_group_name                      = var.resource_group_name
+  location                                 = var.location
+  version                                  = var.db_server_version
+  administrator_login                      = var.db_server_administrator_login
+  administrator_login_password             = var.db_server_administrator_login_password
+  minimum_tls_version                      = var.db_server_minimum_tls_version
+  public_network_access_enabled            = var.db_server_public_network_access_enabled
+  express_vulnerability_assessment_enabled = var.express_vulnerability_assessment_enabled
+  tags                                     = var.tags
 
   lifecycle {
     prevent_destroy = true

--- a/modules/azurerm/MsSQL-Server/mssql_server.tf
+++ b/modules/azurerm/MsSQL-Server/mssql_server.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
 #
 # This software is the property of WSO2 LLC. and its suppliers, if any.
 # Dissemination of any information or reproduction of any material contained

--- a/modules/azurerm/MsSQL-Server/variables.tf
+++ b/modules/azurerm/MsSQL-Server/variables.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
 #
 # This software is the property of WSO2 LLC. and its suppliers, if any.
 # Dissemination of any information or reproduction of any material contained

--- a/modules/azurerm/MsSQL-Server/variables.tf
+++ b/modules/azurerm/MsSQL-Server/variables.tf
@@ -83,3 +83,9 @@ variable "mssql_server_abbreviation" {
   type        = string
   default     = "sql"
 }
+
+variable "express_vulnerability_assessment_enabled" {
+  description = "Enable or disable the Express Vulnerability Assessment for the SQL Server."
+  type        = bool
+  default     = false
+}

--- a/modules/azurerm/MsSQL-Server/versions.tf
+++ b/modules/azurerm/MsSQL-Server/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.52.0"
+      version = ">= 4.27.0"
     }
   }
 }

--- a/modules/azurerm/MsSQL-Server/versions.tf
+++ b/modules/azurerm/MsSQL-Server/versions.tf
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
 #
 # This software is the property of WSO2 LLC. and its suppliers, if any.
 # Dissemination of any information or reproduction of any material contained


### PR DESCRIPTION
## Purpsoe
This pull request introduces updates to the Azure Resource Manager (ARM) Terraform modules for managing SQL Server and SQL Database resources. The changes include copyright updates, configuration enhancements, and version upgrades.

### Copyright Updates:
* Updated the copyright year range from `2023` to `2023-2025` in the following files:
  - `mssql_database.tf`
  - `mssql_server.tf`
  - `variables.tf`
  - `versions.tf`

### Configuration Enhancements:
* Added the `ignore_changes` lifecycle rule for the `auto_pause_delay_in_minutes` property in `azurerm_mssql_database` to prevent unnecessary updates. (`mssql_database.tf`)
* Introduced a new variable `express_vulnerability_assessment_enabled` to enable or disable the Express Vulnerability Assessment feature for SQL Server. This was added to:
  - `variables.tf`
  - `azurerm_mssql_server` resource configuration (`mssql_server.tf`)

### Version Upgrades:
* Updated the required version of the `azurerm` provider from `>= 3.52.0` to `>= 4.27.0` to ensure compatibility with new features. (`versions.tf`)

## Related Issues
- https://github.com/hashicorp/terraform-provider-azurerm/issues/27241