### PR TITLE
Modify Automation Variable to support encryption

### DIFF
--- a/modules/azurerm/Automation-Variable-String/automation_variable_string.tf
+++ b/modules/azurerm/Automation-Variable-String/automation_variable_string.tf
@@ -15,4 +15,5 @@ resource "azurerm_automation_variable_string" "automation_variable_string" {
   resource_group_name     = var.resource_group_name
   name                    = join("-", ["av", each.value.variable_name])
   value                   = each.value.variable_value
+  encrypted               = coalesce(each.value.encrypted, false)
 }

--- a/modules/azurerm/Automation-Variable-String/variables.tf
+++ b/modules/azurerm/Automation-Variable-String/variables.tf
@@ -24,5 +24,6 @@ variable "automation_variables" {
   type = map(object({
     variable_name  = string
     variable_value = string
+    encrypted      = optional(bool)
   }))
 }


### PR DESCRIPTION
## Purpose
> This PR updates the Terraform configuration to ensure that the encrypted attribute is set to true only when each.value.encrypted is explicitly true (boolean)