### PR TITLE
Add Virtual Machine Scale Set name as Module Output 

### DIFF
--- a/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/outputs.tf
+++ b/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/outputs.tf
@@ -20,3 +20,7 @@ output "scale_set_agent_subnet_id" {
 output "network_security_group_id" {
   value = azurerm_network_security_group.scale_set_agent_subnet_nsg.id
 }
+
+output "virtual_machine_scale_set_name" {
+  value = azurerm_linux_virtual_machine_scale_set.scale_set_agent_linux_virtual_machine_scale_set.name
+}


### PR DESCRIPTION
## Purpose
> Expose the Virtual Machine Scale Set name as a module output by adding virtual_machine_scale_set_name to enable external reference.