### PR TITLE
Add a lifecycle ignore changes for the availability zone

### DIFF
--- a/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
+++ b/modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf
@@ -44,7 +44,8 @@ resource "azurerm_postgresql_flexible_server" "postgresql_flexible_server" {
 
   lifecycle {
     ignore_changes = [
-      zone
+      zone,
+      high_availability
     ]
   }
 }


### PR DESCRIPTION
### Purpose ###
This pull request makes a small change to the `azurerm_postgresql_flexible_server` resource in the Terraform configuration. The change updates the `ignore_changes` block to include `high_availability` in addition to `zone`.

* [`modules/azurerm/PostgreSQL-Flexible-Server/postgresql_server.tf`](diffhunk://#diff-caa18f8d870974df5b188513c2968995402b12655000c299f944a4cb586542deL47-R48): Added `high_availability` to the `ignore_changes` list in the `lifecycle` block of the `azurerm_postgresql_flexible_server` resource.

- https://github.com/wso2-enterprise/product-pic/issues/391