### PR TITLE
Add AMA Settings & Conditional Network Rules

### DIFF
--- a/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/variables.tf
+++ b/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/variables.tf
@@ -151,3 +151,9 @@ variable "os_disk_size_gb" {
   description = "The size of the OS disk in GB"
   type        = number
 }
+
+variable "ama_settings" {
+  default     = null
+  description = "The settings for the Azure Monitor Agent"
+  type        = string
+}

--- a/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/virtual_machine_scale_set_extension.tf
+++ b/modules/azurerm/Azure-DevOps-Custom-Image-Scale-Set-Agents/virtual_machine_scale_set_extension.tf
@@ -18,6 +18,7 @@ resource "azurerm_virtual_machine_scale_set_extension" "azure_monitor_agent_exte
   type_handler_version         = var.ama_type_handler_version
   auto_upgrade_minor_version   = var.ama_auto_upgrade_minor_version
   automatic_upgrade_enabled    = var.ama_automatic_upgrade_enabled
+  settings                     = var.ama_settings
 
   lifecycle {
     ignore_changes = [

--- a/modules/azurerm/Storage-Account-Static-Website-CDN/storage_account_static_website.tf
+++ b/modules/azurerm/Storage-Account-Static-Website-CDN/storage_account_static_website.tf
@@ -37,11 +37,14 @@ resource "azurerm_storage_account" "static_storage" {
     }
   }
 
-  network_rules {
-    default_action             = var.network_rules_default_action
-    ip_rules                   = var.network_rules_ip_whitelist
-    virtual_network_subnet_ids = var.network_rules_subnet_ids
-    bypass                     = var.network_rules_bypass
+  dynamic "network_rules" {
+    for_each = var.network_rules_enabled ? [1] : []
+    content {
+      default_action             = var.network_rules_default_action
+      ip_rules                   = var.network_rules_ip_whitelist
+      virtual_network_subnet_ids = var.network_rules_subnet_ids
+      bypass                     = var.network_rules_bypass
+    }
   }
 
   static_website {

--- a/modules/azurerm/Storage-Account-Static-Website-CDN/variables.tf
+++ b/modules/azurerm/Storage-Account-Static-Website-CDN/variables.tf
@@ -127,3 +127,9 @@ variable "cross_tenant_replication_enabled" {
   description = "Enable or disable cross tenant replication"
   type        = bool
 }
+
+variable "network_rules_enabled" {
+  default     = true
+  description = "Enable or disable network rules for the storage account"
+  type        = bool
+}

--- a/modules/azurerm/Storage-Account-Static-Website/storage_account_static_website.tf
+++ b/modules/azurerm/Storage-Account-Static-Website/storage_account_static_website.tf
@@ -28,11 +28,14 @@ resource "azurerm_storage_account" "static_storage" {
     }
   }
 
-  network_rules {
-    default_action             = var.network_rules_default_action
-    ip_rules                   = var.network_rules_ip_whitelist
-    virtual_network_subnet_ids = var.network_rules_subnet_ids
-    bypass                     = var.network_rules_bypass
+  dynamic "network_rules" {
+    for_each = var.network_rules_enabled ? [1] : []
+    content {
+      default_action             = var.network_rules_default_action
+      ip_rules                   = var.network_rules_ip_whitelist
+      virtual_network_subnet_ids = var.network_rules_subnet_ids
+      bypass                     = var.network_rules_bypass
+    }
   }
 
   static_website {

--- a/modules/azurerm/Storage-Account-Static-Website/variables.tf
+++ b/modules/azurerm/Storage-Account-Static-Website/variables.tf
@@ -84,3 +84,9 @@ variable "cross_tenant_replication_enabled" {
   description = "Enable or disable cross tenant replication"
   type        = bool
 }
+
+variable "network_rules_enabled" {
+  default     = true
+  description = "Enable or disable network rules for the storage account"
+  type        = bool
+}


### PR DESCRIPTION
### Description

This pull request introduces enhancements to Azure resource modules, focusing on improved configurability and flexibility. Key changes include the addition of new variables for Azure Monitor Agent settings and network rules, as well as updates to resource definitions to support dynamic configurations based on these variables.

### Enhancements to Azure Monitor Agent configuration:

* Added a new variable, `ama_settings`, to allow customizable settings for the Azure Monitor Agent in the `Azure-DevOps-Custom-Image-Scale-Set-Agents` module (`variables.tf`).
* Updated the `azurerm_virtual_machine_scale_set_extension` resource to use the `ama_settings` variable for agent configuration (`virtual_machine_scale_set_extension.tf`).

### Improvements to storage account network rules:

* Introduced a new variable, `network_rules_enabled`, to enable or disable network rules dynamically in the `Storage-Account-Static-Website-CDN` module (`variables.tf`).
* Updated the `azurerm_storage_account` resource to use a `dynamic` block for network rules, controlled by the `network_rules_enabled` variable (`storage_account_static_website.tf`).

### Parallel changes in another storage account module:

* Mirrored the addition of the `network_rules_enabled` variable in the `Storage-Account-Static-Website` module (`variables.tf`).
* Applied the same `dynamic` block approach for network rules in the `azurerm_storage_account` resource within this module (`storage_account_static_website.tf`).