### PR TITLE
Support Network ACLs & AzureRM >=2.44.0

### DIFF
--- a/modules/azuread/Application/outputs.tf
+++ b/modules/azuread/Application/outputs.tf
@@ -10,11 +10,16 @@
 # --------------------------------------------------------------------------------------
 
 output "application_id" {
-  value      = azuread_application.ad_application.application_id
+  value      = azuread_application.ad_application.id
   depends_on = [azuread_application.ad_application]
 }
 
 output "object_id" {
   value      = azuread_application.ad_application.object_id
+  depends_on = [azuread_application.ad_application]
+}
+
+output "client_id" {
+  value      = azuread_application.ad_application.client_id
   depends_on = [azuread_application.ad_application]
 }

--- a/modules/azuread/Application/versions.tf
+++ b/modules/azuread/Application/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = ">= 2.14.0"
+      version = ">= 2.44.0"
     }
   }
 }

--- a/modules/azurerm/Azure-OpenAI-Service/azure_openai_service.tf
+++ b/modules/azurerm/Azure-OpenAI-Service/azure_openai_service.tf
@@ -19,7 +19,18 @@ resource "azurerm_cognitive_account" "azure_openai_account" {
   outbound_network_access_restricted = var.outbound_network_access_restricted
   public_network_access_enabled      = var.public_network_access_enabled
   custom_subdomain_name              = join("-", [var.cognitive_account_abbreviation, var.custom_subdomain_name])
-  tags                               = var.tags
+
+  dynamic "network_acls" {
+    for_each = var.network_acls_enabled ? [1] : []
+
+    content {
+      default_action = var.network_acls_default_action
+      bypass         = var.network_acls_bypass
+      ip_rules       = var.network_acls_ip_rules
+    }
+  }
+
+  tags = var.tags
 }
 
 resource "azurerm_cognitive_deployment" "azure_openai_deployment" {

--- a/modules/azurerm/Azure-OpenAI-Service/variables.tf
+++ b/modules/azurerm/Azure-OpenAI-Service/variables.tf
@@ -98,3 +98,27 @@ variable "azure_openai_deployments" {
     deployment_sku_capacity   = string
   }))
 }
+
+variable "network_acls_enabled" {
+  description = "Boolean flag to specify whether Network ACLs should be enabled for the Cognitive Account."
+  type        = bool
+  default     = false
+}
+
+variable "network_acls_default_action" {
+  description = "The Default Action for the Network ACLs."
+  type        = string
+  default     = "Deny"
+}
+
+variable "network_acls_bypass" {
+  description = "Specifies which traffic can bypass the network rules. Possible values are AzureServices and None."
+  type        = string
+  default     = "AzureServices"
+}
+
+variable "network_acls_ip_rules" {
+  description = "One or more IP Addresses, or CIDR Blocks which should be able to access the Cognitive Account."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
### Description

This pull request introduces updates to the AzureAD and Azure OpenAI Service modules, focusing on enhancing functionality and compatibility. The changes include adding new outputs for AzureAD applications, updating provider versions, and enabling dynamic configuration for network ACLs in the Azure OpenAI Service.

### Updates to AzureAD module:

* **Change in output values**:
  - Updated the `application_id` output to use `azuread_application.ad_application.id` instead of `application_id` for consistency.
  - Added a new output `client_id` to expose the client ID of the AzureAD application.

* **Provider version update**:
  - Increased the required version of the `azuread` provider from `>= 2.14.0` to `>= 2.44.0` to ensure compatibility with newer features.

### Enhancements to Azure OpenAI Service module:

* **Dynamic network ACLs configuration**:
  - Added a `dynamic` block in the `azurerm_cognitive_account` resource to enable conditional configuration of network ACLs based on the `network_acls_enabled` variable. This includes settings for default actions, bypass rules, and IP rules.

* **New variables for network ACLs**:
  - Introduced variables (`network_acls_enabled`, `network_acls_default_action`, `network_acls_bypass`, `network_acls_ip_rules`) to support flexible configuration of network ACLs. These variables allow users to define whether ACLs are enabled and specify their behavior.