### PR TITLE
Add optional mapping for storage management policy rule

### DIFF
--- a/modules/azurerm/Storage-Management-Policy/variables.tf
+++ b/modules/azurerm/Storage-Management-Policy/variables.tf
@@ -23,9 +23,9 @@ variable "rules" {
       blob_types   = list(string),
       object_rules = list(object({
         for_object           = string
-        delete_in_days       = number
-        move_to_cold_tier_in = number
-        archive_in           = number
+        delete_in_days       = optional(number)
+        move_to_cold_tier_in = optional(number)
+        archive_in           = optional(number)
       }))
     })
   )


### PR DESCRIPTION
## Purpose
Made numeric fields in the rules.object_rules input optional:

1. delete_in_days
2. move_to_cold_tier_in
3. archive_in

This change allows module consumers to define storage lifecycle rules more selectively without needing to provide all values.