### PR TITLE
Create a Module for Entra app + Role Assignment

### DIFF
--- a/modules/azuread/Application-Role-Assignment/main.tf
+++ b/modules/azuread/Application-Role-Assignment/main.tf
@@ -1,0 +1,64 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azuread_application" "app" {
+  display_name = var.entra_app_display_name
+  description  = var.description
+  owners       = var.owners
+
+  dynamic "required_resource_access" {
+    for_each = var.required_resource_access_map
+    content {
+      resource_app_id = required_resource_access.key
+
+      dynamic "resource_access" {
+        for_each = required_resource_access.value
+        content {
+          id   = resource_access.key
+          type = resource_access.value
+        }
+      }
+    }
+  }
+}
+
+resource "azuread_service_principal" "sp" {
+  client_id  = azuread_application.app.client_id
+  depends_on = [azuread_application.app]
+}
+
+resource "azurerm_role_assignment" "role_assignment" {
+  for_each             = var.role_assignments
+  scope                = each.value.scope
+  role_definition_name = each.value.role_definition_name
+  principal_id         = azuread_service_principal.sp.object_id
+  depends_on           = [azuread_service_principal.sp]
+}
+
+resource "azurerm_role_definition" "custom_role" {
+  for_each = var.custom_role_definitions
+
+  name        = each.value.name
+  description = each.value.description
+  scope       = each.value.scope
+
+  permissions {
+    actions = each.value.permissions
+  }
+}
+
+resource "azurerm_role_assignment" "custom_role_assignment" {
+  for_each           = var.custom_role_definitions
+  scope              = each.value.scope
+  role_definition_id = azurerm_role_definition.custom_role[each.key].role_definition_resource_id
+  principal_id       = azuread_service_principal.sp.object_id
+  depends_on         = [azuread_service_principal.sp]
+}

--- a/modules/azuread/Application-Role-Assignment/outputs.tf
+++ b/modules/azuread/Application-Role-Assignment/outputs.tf
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+output "client_id" {
+  description = "The client ID of the Azure AD application."
+  value       = azuread_application.app.client_id
+}
+
+output "object_id" {
+  description = "The object ID of the service principal."
+  value       = azuread_service_principal.sp.object_id
+}

--- a/modules/azuread/Application-Role-Assignment/variables.tf
+++ b/modules/azuread/Application-Role-Assignment/variables.tf
@@ -1,0 +1,51 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+variable "entra_app_display_name" {
+  description = "The display name of the Azure AD application."
+  type        = string
+}
+
+variable "description" {
+  description = "The description of the Azure AD application."
+  type        = string
+}
+
+variable "owners" {
+  type        = set(string)
+  description = "A set of object ids of the owners of the Azure AD application."
+}
+
+variable "role_assignments" {
+  description = "A map of role assignments with scope and role definition name."
+  type = map(object({
+    scope                = string
+    role_definition_name = string
+  }))
+  default = null
+}
+
+variable "required_resource_access_map" {
+  description = "A map of resource_app_id to a map of resource_access objects."
+  type        = map(map(string))
+  default     = null
+}
+
+variable "custom_role_definitions" {
+  description = "Map of custom role definitions"
+  type = map(object({
+    name        = string
+    description = string
+    permissions = list(string)
+    scope       = string
+  }))
+  default = {}
+}

--- a/modules/azuread/Application-Role-Assignment/versions.tf
+++ b/modules/azuread/Application-Role-Assignment/versions.tf
@@ -1,0 +1,24 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 2.44.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

Created this module since it is common to have a service principal and role assignments when an AD (entra) app is provisioned. The purpose is to reduce the repetitions and avoid wrapping single terraform resource inside a module.