### PR TITLE
Update variable default values for Cdn Frontdoor custom domains

### DIFF
--- a/modules/azurerm/CDN-FrontDoor-Custom-Domain/variables.tf
+++ b/modules/azurerm/CDN-FrontDoor-Custom-Domain/variables.tf
@@ -37,6 +37,7 @@ variable "cdn_frontdoor_profile_id" {
 variable "dns_zone_id" {
   description = "The ID of the DNS Zone."
   type        = string
+  default     = null
 }
 
 variable "host_name" {
@@ -47,6 +48,7 @@ variable "host_name" {
 variable "certificate_type" {
   description = "The type of the certificate."
   type        = string
+  default     = "ManagedCertificate"
 }
 
 variable "minimum_tls_version" {
@@ -58,4 +60,5 @@ variable "minimum_tls_version" {
 variable "cdn_frontdoor_secret_id" {
   description = "The ID of the CDN Front Door Secret."
   type        = string
+  default     = null
 }


### PR DESCRIPTION
## Purpose
The module was updated to add default values for several variables used in `modules/azurerm/CDN-FrontDoor-Custom-Domain/variables.tf`. The `dns_zone_id` and `cdn_frontdoor_secret_id` variables now default to null, allowing them to be optional. The `certificate_type` variable was given a default value of "ManagedCertificate", ensuring that users can deploy the module without explicitly specifying these values. These changes simplify module usage and reduce the need to provide redundant inputs.