### PR TITLE
Add ip prefix as output for Public IP Prefix Module

### DIFF
--- a/modules/azurerm/Public-IP-Prefix/outputs.tf
+++ b/modules/azurerm/Public-IP-Prefix/outputs.tf
@@ -13,3 +13,8 @@ output "public_ip_prefix_id" {
   depends_on = [azurerm_public_ip_prefix.public_ip_prefix]
   value      = azurerm_public_ip_prefix.public_ip_prefix.id
 }
+
+output "ip_prefix" {
+  depends_on = [azurerm_public_ip_prefix.public_ip_prefix]
+  value      = azurerm_public_ip_prefix.public_ip_prefix.ip_prefix
+}


### PR DESCRIPTION
## Purpose
> Added Terraform output `ip_prefix` to expose the `ip_prefix` value from `azurerm_public_ip_prefix.public_ip_prefix`.
