### PR TITLE
Add custom webhook payload support to scheduled query rules alerts

### DIFF
--- a/modules/azurerm/Monitor-Scheduled-Query-Alert/monitor_scheduled_query_alert.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert/monitor_scheduled_query_alert.tf
@@ -24,7 +24,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "scheduled_query_rules_al
   tags                = merge(var.tags, { "enabled" : each.value.query_enabled })
 
   action {
-    action_group = each.value.action_group_id_list
+    action_group           = each.value.action_group_id_list
+    custom_webhook_payload = each.value.custom_webhook_payload
   }
 
   trigger {
@@ -55,7 +56,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "count_trigger_scheduled_
   tags                = merge(var.tags, { "enabled" : each.value.query_enabled })
 
   action {
-    action_group = each.value.action_group_id_list
+    action_group           = each.value.action_group_id_list
+    custom_webhook_payload = each.value.custom_webhook_payload
   }
 
   trigger {

--- a/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
@@ -37,7 +37,7 @@ variable "query_rules_alert" {
     metric_threshold           = number
     metric_trigger_type        = string
     metric_column              = string
-    custom_webhook_payload     = string
+    custom_webhook_payload     = optional(string)
   }))
 }
 
@@ -55,7 +55,7 @@ variable "count_trigger_query_rules_alert" {
     time_window                = number
     operator                   = string
     threshold                  = number
-    custom_webhook_payload     = string
+    custom_webhook_payload     = optional(string)
   }))
 }
 

--- a/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
@@ -37,6 +37,7 @@ variable "query_rules_alert" {
     metric_threshold           = number
     metric_trigger_type        = string
     metric_column              = string
+    custom_webhook_payload     = string
   }))
 }
 
@@ -54,6 +55,7 @@ variable "count_trigger_query_rules_alert" {
     time_window                = number
     operator                   = string
     threshold                  = number
+    custom_webhook_payload     = string
   }))
 }
 


### PR DESCRIPTION
This pull request enhances the Azure Monitor Scheduled Query Alert module by adding support for specifying a custom webhook payload in alert actions. This allows users to define custom data sent to webhook endpoints when alerts are triggered.

**Support for custom webhook payloads:**

* Added the `custom_webhook_payload` attribute to the `action` block of both the `azurerm_monitor_scheduled_query_rules_alert` and `count_trigger_scheduled_query_rules_alert` resources, enabling custom payloads for webhook notifications. [[1]](diffhunk://#diff-2c67a1ccf4d6258aeb1d7c30434e75a887b826fe7beaa075d9880d233e3da277R28) [[2]](diffhunk://#diff-2c67a1ccf4d6258aeb1d7c30434e75a887b826fe7beaa075d9880d233e3da277R60)
* Updated the `query_rules_alert` and `count_trigger_query_rules_alert` variable definitions to include the new `custom_webhook_payload` field, allowing users to pass custom payloads via module input. [[1]](diffhunk://#diff-a1a23b93eca1aa37b1fa1cc46b2727cc9b5b9eb74c3082584a35aa81eaeb54faR40) [[2]](diffhunk://#diff-a1a23b93eca1aa37b1fa1cc46b2727cc9b5b9eb74c3082584a35aa81eaeb54faR58)