### PR TITLE
Add optional webhook and custom properties to alert configurations

### DIFF
--- a/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/monitor_activity_log_administrative_alerts.tf
+++ b/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/monitor_activity_log_administrative_alerts.tf
@@ -26,6 +26,7 @@ resource "azurerm_monitor_activity_log_alert" "monitor_activity_log_administrati
   }
 
   action {
-    action_group_id = each.value.monitor_action_group_id
+    action_group_id    = each.value.monitor_action_group_id
+    webhook_properties = each.value.webhook_properties
   }
 }

--- a/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/variables.tf
+++ b/modules/azurerm/Monitor-Activity-Log-Administrative-Alerts/variables.tf
@@ -36,6 +36,7 @@ variable "activity_log_administrative_alerts" {
     operation_name                  = string
     resource_id                     = string
     scopes                          = list(string)
+    webhook_properties              = optional(map(string))
   }))
 }
 

--- a/modules/azurerm/Monitor-Log-Alerts/variables.tf
+++ b/modules/azurerm/Monitor-Log-Alerts/variables.tf
@@ -34,7 +34,7 @@ variable "recommendation_alerts" {
     monitor_action_group_id = string
     recommendation_impact   = string
     scopes                  = list(string)
-    webhook_properties      = map(string)
+    webhook_properties      = optional(map(string))
   }))
 }
 
@@ -48,7 +48,7 @@ variable "activity_log_alerts" {
     location                = string
     monitor_action_group_id = string
     scopes                  = list(string)
-    webhook_properties      = map(string)
+    webhook_properties      = optional(map(string))
   }))
 }
 
@@ -70,7 +70,7 @@ variable "resource_health_alerts" {
     target_resource_group   = string
     target_resource_id      = string
     target_resource_type    = string
-    webhook_properties      = map(string)
+    webhook_properties      = optional(map(string))
   }))
 }
 
@@ -87,7 +87,7 @@ variable "service_health_alerts" {
     scopes                  = list(string)
     targetEvents            = list(string)
     targetLocations         = list(string)
-    webhook_properties      = map(string)
+    webhook_properties      = optional(map(string))
   }))
 }
 
@@ -104,7 +104,7 @@ variable "specific_service_health_alerts" {
     targetEvents            = list(string)
     targetLocations         = list(string)
     targetServices          = list(string)
-    webhook_properties      = map(string)
+    webhook_properties      = optional(map(string))
   }))
 }
 

--- a/modules/azurerm/Monitor-Metric-Alerts/monitor_metrics_alerts.tf
+++ b/modules/azurerm/Monitor-Metric-Alerts/monitor_metrics_alerts.tf
@@ -43,7 +43,8 @@ resource "azurerm_monitor_metric_alert" "monitor_metric_alert_with_2_dimensions"
   }
 
   action {
-    action_group_id = each.value.monitor_action_group_id
+    action_group_id    = each.value.monitor_action_group_id
+    webhook_properties = each.value.webhook_properties
   }
 }
 
@@ -75,7 +76,8 @@ resource "azurerm_monitor_metric_alert" "monitor_metric_alert_with_1_dimension" 
   }
 
   action {
-    action_group_id = each.value.monitor_action_group_id
+    action_group_id    = each.value.monitor_action_group_id
+    webhook_properties = each.value.webhook_properties
   }
 }
 
@@ -101,6 +103,7 @@ resource "azurerm_monitor_metric_alert" "monitor_metric_alert" {
   }
 
   action {
-    action_group_id = each.value.monitor_action_group_id
+    action_group_id    = each.value.monitor_action_group_id
+    webhook_properties = each.value.webhook_properties
   }
 }

--- a/modules/azurerm/Monitor-Metric-Alerts/variables.tf
+++ b/modules/azurerm/Monitor-Metric-Alerts/variables.tf
@@ -52,6 +52,7 @@ variable "metric_alerts_with_2_dimensions" {
     dimension_2_name          = string
     dimension_2_operator      = string
     dimension_2_values        = list(string)
+    webhook_properties        = optional(map(string))
   }))
 }
 
@@ -74,6 +75,7 @@ variable "metric_alerts_with_1_dimension" {
     dimension_1_name          = string
     dimension_1_operator      = string
     dimension_1_values        = list(string)
+    webhook_properties        = optional(map(string))
   }))
 }
 
@@ -93,6 +95,7 @@ variable "metric_alerts" {
     criteria_aggregation      = string
     criteria_operator         = string
     criteria_threshold        = number
+    webhook_properties        = optional(map(string))
   }))
 }
 

--- a/modules/azurerm/Monitor-Scheduled-Query-Alert/monitor_scheduled_query_alert.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert/monitor_scheduled_query_alert.tf
@@ -23,7 +23,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "scheduled_query_rules
   tags                 = merge(var.tags, { "enabled" : each.value.query_enabled })
 
   action {
-    action_groups = each.value.action_group_id_list
+    action_groups     = each.value.action_group_id_list
+    custom_properties = each.value.custom_properties
   }
 
   criteria {
@@ -69,7 +70,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "count_trigger_schedul
   tags                 = merge(var.tags, { "enabled" : each.value.query_enabled })
 
   action {
-    action_groups = each.value.action_group_id_list
+    action_groups     = each.value.action_group_id_list
+    custom_properties = each.value.custom_properties
   }
 
   criteria {

--- a/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
@@ -44,6 +44,7 @@ variable "query_rules_alert" {
       number_of_evaluation_periods             = number
     }))
     metric_measure_column = string
+    custom_properties    = optional(map(string))
   }))
 }
 
@@ -61,6 +62,7 @@ variable "count_trigger_query_rules_alert" {
     window_duration      = string
     operator             = string
     threshold            = number
+    custom_properties    = optional(map(string))
   }))
 }
 

--- a/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
@@ -44,7 +44,7 @@ variable "query_rules_alert" {
       number_of_evaluation_periods             = number
     }))
     metric_measure_column = string
-    custom_properties    = optional(map(string))
+    custom_properties     = optional(map(string))
   }))
 }
 


### PR DESCRIPTION
This pull request adds support for optional webhook and custom properties in various Azure Monitor alert modules. The main goal is to allow users to specify additional properties for alert actions (such as webhooks and custom properties) in a flexible way, by making these fields optional in the input variables and passing them through to the relevant resources.

The most important changes are:

**Support for Optional Webhook Properties in Monitor Log and Metric Alerts**
- Made the `webhook_properties` field optional in all relevant input variables for log alerts (`recommendation_alerts`, `activity_log_alerts`, `resource_health_alerts`, `service_health_alerts`, `specific_service_health_alerts`) and metric alerts (`metric_alerts`, `metric_alerts_with_1_dimension`, `metric_alerts_with_2_dimensions`) to allow flexibility in specifying webhook properties. [[1]](diffhunk://#diff-c076b368f0dd9a15e36b53ddb69dfc0160f1d9cb316593d4da99cafd67bf1556L37-R37) [[2]](diffhunk://#diff-c076b368f0dd9a15e36b53ddb69dfc0160f1d9cb316593d4da99cafd67bf1556L51-R51) [[3]](diffhunk://#diff-c076b368f0dd9a15e36b53ddb69dfc0160f1d9cb316593d4da99cafd67bf1556L73-R73) [[4]](diffhunk://#diff-c076b368f0dd9a15e36b53ddb69dfc0160f1d9cb316593d4da99cafd67bf1556L90-R90) [[5]](diffhunk://#diff-c076b368f0dd9a15e36b53ddb69dfc0160f1d9cb316593d4da99cafd67bf1556L107-R107) [[6]](diffhunk://#diff-2f1e3493d219bc3ea78b1669ff9f7bf2fa5e70f52fbbfb4ced9eee26283287ceR55) [[7]](diffhunk://#diff-2f1e3493d219bc3ea78b1669ff9f7bf2fa5e70f52fbbfb4ced9eee26283287ceR78) [[8]](diffhunk://#diff-2f1e3493d219bc3ea78b1669ff9f7bf2fa5e70f52fbbfb4ced9eee26283287ceR98) [[9]](diffhunk://#diff-53776221936092cf13206307029c91200bde6c36bc4d5c0221a6fe7d7a697cbeR39)

- Updated the corresponding resource definitions to pass `webhook_properties` to the `action` block for both activity log and metric alerts. [[1]](diffhunk://#diff-8e0a92fb12069ee1d4dcd3205dccfd8c42c0c4bf0bf854b0688084fe92a6ec99R30) [[2]](diffhunk://#diff-85afb038f8544990d171b3c2b97e7ec2721c39b939c98630b817713e8df3f526R47) [[3]](diffhunk://#diff-85afb038f8544990d171b3c2b97e7ec2721c39b939c98630b817713e8df3f526R80) [[4]](diffhunk://#diff-85afb038f8544990d171b3c2b97e7ec2721c39b939c98630b817713e8df3f526R107)

**Support for Optional Custom Properties in Scheduled Query Alerts**
- Added an optional `custom_properties` field to the scheduled query alert input variables (`query_rules_alert`, `count_trigger_query_rules_alert`) and passed it through to the `action` block in the related resources. [[1]](diffhunk://#diff-a1a23b93eca1aa37b1fa1cc46b2727cc9b5b9eb74c3082584a35aa81eaeb54faR47) [[2]](diffhunk://#diff-a1a23b93eca1aa37b1fa1cc46b2727cc9b5b9eb74c3082584a35aa81eaeb54faR65) [[3]](diffhunk://#diff-2c67a1ccf4d6258aeb1d7c30434e75a887b826fe7beaa075d9880d233e3da277R27) [[4]](diffhunk://#diff-2c67a1ccf4d6258aeb1d7c30434e75a887b826fe7beaa075d9880d233e3da277R74)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled webhook properties for Activity Log and Metric alert actions.
  * Made webhook properties optional across all Log alert types for greater configuration flexibility.
  * Enabled custom properties for Scheduled Query alert actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->