### PR TITLE
[main] Update cdn-frontdoor-profile to handle identity ids

### DIFF
--- a/modules/azurerm/CDN-FrontDoor-Profile/cdn_frontdoor_profile.tf
+++ b/modules/azurerm/CDN-FrontDoor-Profile/cdn_frontdoor_profile.tf
@@ -24,4 +24,12 @@ resource "azurerm_cdn_frontdoor_profile" "cdn_frontdoor_profile" {
   sku_name                 = var.sku_name
   response_timeout_seconds = var.response_timeout_seconds
   tags                     = var.tags
+
+  dynamic "identity" {
+    for_each = var.identity != null ? [var.identity] : []
+    content {
+      type         = identity.value.type
+      identity_ids = identity.value.identity_ids
+    }
+  }
 }

--- a/modules/azurerm/CDN-FrontDoor-Profile/outputs.tf
+++ b/modules/azurerm/CDN-FrontDoor-Profile/outputs.tf
@@ -32,3 +32,8 @@ output "resource_guid" {
   depends_on = [azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile]
   value      = azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile.resource_guid
 }
+
+output "identity" {
+  depends_on = [azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile]
+  value      = azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile.identity
+}

--- a/modules/azurerm/CDN-FrontDoor-Profile/outputs.tf
+++ b/modules/azurerm/CDN-FrontDoor-Profile/outputs.tf
@@ -32,8 +32,3 @@ output "resource_guid" {
   depends_on = [azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile]
   value      = azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile.resource_guid
 }
-
-output "identity" {
-  depends_on = [azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile]
-  value      = azurerm_cdn_frontdoor_profile.cdn_frontdoor_profile.identity
-}

--- a/modules/azurerm/CDN-FrontDoor-Profile/variables.tf
+++ b/modules/azurerm/CDN-FrontDoor-Profile/variables.tf
@@ -51,3 +51,12 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "identity" {
+  description = "The identity block for the CDN Frontdoor Profile."
+  type = object({
+    type         = string
+    identity_ids = optional(list(string), [])
+  })
+  default = null
+}


### PR DESCRIPTION
### Purpose
This pull request adds support for configuring managed identities on the `azurerm_cdn_frontdoor_profile` resource. The changes introduce a new `identity` variable, update the resource to conditionally include the identity block, and output the configured identity.

**Managed Identity Support:**

* Added a new `identity` variable to allow users to specify the managed identity configuration for the CDN Front Door Profile.
* Updated the `azurerm_cdn_frontdoor_profile` resource to dynamically include the `identity` block if the `identity` variable is set.
* Added an `identity` output to expose the configured identity details.