### PR TITLE
Add Docker Registry, Monitor Alert, and MySQL modules with Refactor

### DIFF
--- a/modules/azuredevops/Docker-Registry-Service-Endpoint/dockerregistry_service_endpoint.tf
+++ b/modules/azuredevops/Docker-Registry-Service-Endpoint/dockerregistry_service_endpoint.tf
@@ -1,0 +1,30 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azuredevops_serviceendpoint_dockerregistry" "devops_serviceendpoint_dockerregistry" {
+  project_id            = var.project_id
+  service_endpoint_name = var.service_endpoint_name
+  description           = var.description
+  docker_registry       = var.docker_registry
+  docker_username       = var.docker_username
+  docker_email          = var.docker_email
+  docker_password       = var.docker_password
+  registry_type         = var.registry_type
+}

--- a/modules/azuredevops/Docker-Registry-Service-Endpoint/outputs.tf
+++ b/modules/azuredevops/Docker-Registry-Service-Endpoint/outputs.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "serviceendpoint_id" {
+  depends_on = [azuredevops_serviceendpoint_dockerregistry.devops_serviceendpoint_dockerregistry]
+  value      = azuredevops_serviceendpoint_dockerregistry.devops_serviceendpoint_dockerregistry.id
+}
+
+output "serviceendpoint_name" {
+  depends_on = [azuredevops_serviceendpoint_dockerregistry.devops_serviceendpoint_dockerregistry]
+  value      = azuredevops_serviceendpoint_dockerregistry.devops_serviceendpoint_dockerregistry.service_endpoint_name
+}

--- a/modules/azuredevops/Docker-Registry-Service-Endpoint/variables.tf
+++ b/modules/azuredevops/Docker-Registry-Service-Endpoint/variables.tf
@@ -1,0 +1,64 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "project_id" {
+  description = "The ID of the project."
+  type        = string
+}
+
+variable "service_endpoint_name" {
+  description = "The name of the service endpoint."
+  type        = string
+}
+
+variable "description" {
+  description = "The description of the service endpoint."
+  type        = string
+}
+
+variable "docker_registry" {
+  description = "The URL of the Docker registry."
+  type        = string
+}
+
+variable "docker_username" {
+  description = "The username for the Docker registry."
+  type        = string
+  sensitive   = true
+}
+
+variable "docker_email" {
+  description = "The email for the Docker registry."
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "docker_password" {
+  description = "The password for the Docker registry."
+  type        = string
+  sensitive   = true
+}
+
+variable "registry_type" {
+  description = "The type of the Docker registry."
+  type        = string
+  default     = "DockerHub"
+}

--- a/modules/azuredevops/Docker-Registry-Service-Endpoint/versions.tf
+++ b/modules/azuredevops/Docker-Registry-Service-Endpoint/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azuredevops = {
+      source  = "microsoft/azuredevops"
+      version = ">=0.1.0"
+    }
+  }
+}

--- a/modules/azurerm/AKS-Generic/aks_cluster.tf
+++ b/modules/azurerm/AKS-Generic/aks_cluster.tf
@@ -10,12 +10,12 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_kubernetes_cluster" "aks_cluster" {
-  name                                = join("-", ["aks", var.aks_cluster_name])
+  name                                = join("-", compact([var.aks_cluster_abbreviation, var.aks_cluster_name]))
   location                            = var.location
   resource_group_name                 = var.aks_resource_group_name
-  dns_prefix                          = join("-", ["aks", var.aks_cluster_dns_prefix])
+  dns_prefix                          = join("-", compact([var.aks_cluster_abbreviation, var.aks_cluster_dns_prefix]))
   kubernetes_version                  = var.kubernetes_version
-  node_resource_group                 = join("-", ["rg", var.aks_node_pool_resource_group_name])
+  node_resource_group                 = join("-", compact([var.resource_group_abbreviation, var.aks_node_pool_resource_group_name]))
   sku_tier                            = var.sku_tier
   private_cluster_enabled             = var.private_cluster_enabled
   private_cluster_public_fqdn_enabled = var.private_cluster_public_fqdn_enable
@@ -39,7 +39,7 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
   }
 
   default_node_pool {
-    name                         = join("", ["aksnp", var.default_node_pool_name])
+    name                         = join("", compact([var.aks_node_pool_abbreviation, var.default_node_pool_name]))
     node_count                   = var.default_node_pool_count
     vm_size                      = var.default_node_pool_vm_size
     zones                        = var.default_node_pool_availability_zones

--- a/modules/azurerm/AKS-Generic/network.tf
+++ b/modules/azurerm/AKS-Generic/network.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_subnet" "aks_node_pool_subnet" {
-  name                              = join("-", ["snet", var.aks_node_pool_subnet_name])
+  name                              = join("-", compact([var.aks_node_pool_subnet_abbreviation, var.aks_node_pool_subnet_name]))
   resource_group_name               = local.virtual_network_resource_group_name
   virtual_network_name              = var.virtual_network_name
   address_prefixes                  = [var.aks_node_pool_subnet_address_prefix]
@@ -19,7 +19,7 @@ resource "azurerm_subnet" "aks_node_pool_subnet" {
 }
 
 resource "azurerm_route_table" "aks_node_pool_route_table" {
-  name                = join("-", ["route", var.aks_node_pool_subnet_route_table_name])
+  name                = join("-", compact([var.aks_node_pool_subnet_route_table_abbreviation, var.aks_node_pool_subnet_route_table_name]))
   location            = var.location
   resource_group_name = local.virtual_network_resource_group_name
   tags                = var.tags
@@ -43,7 +43,7 @@ resource "azurerm_subnet_route_table_association" "subnet_rt_association" {
 
 resource "azurerm_network_security_group" "aks_node_pool_subnet_nsg" {
   location            = var.location
-  name                = join("-", ["nsg", var.aks_node_pool_subnet_network_security_group_name])
+  name                = join("-", compact([var.aks_node_pool_subnet_network_security_group_abbreviation, var.aks_node_pool_subnet_network_security_group_name]))
   resource_group_name = local.virtual_network_resource_group_name
 }
 

--- a/modules/azurerm/AKS-Generic/variables.tf
+++ b/modules/azurerm/AKS-Generic/variables.tf
@@ -328,3 +328,39 @@ variable "default_node_pool_max_surge" {
   type        = string
   default     = "10%"
 }
+
+variable "aks_cluster_abbreviation" {
+  description = "Abbreviation to be used in naming the AKS cluster and its resources"
+  type        = string
+  default     = "aks"
+}
+
+variable "resource_group_abbreviation" {
+  description = "Abbreviation to be used in naming the resource groups of the AKS cluster and its resources"
+  type        = string
+  default     = "rg"
+}
+
+variable "aks_node_pool_abbreviation" {
+  description = "Abbreviation to be used in naming the node pools of the AKS cluster and its resources"
+  type        = string
+  default     = "aksnp"
+}
+
+variable "aks_node_pool_subnet_network_security_group_abbreviation" {
+  description = "Abbreviation to be used in naming the network security group of the node pool subnet"
+  type        = string
+  default     = "nsg"
+}
+
+variable "aks_node_pool_subnet_route_table_abbreviation" {
+  description = "Abbreviation to be used in naming the route table of the node pool subnet"
+  type        = string
+  default     = "route"
+}
+
+variable "aks_node_pool_subnet_abbreviation" {
+  description = "Abbreviation to be used in naming the node pool subnet"
+  type        = string
+  default     = "snet"
+}

--- a/modules/azurerm/Application-Gateway/application_gateway.tf
+++ b/modules/azurerm/Application-Gateway/application_gateway.tf
@@ -11,7 +11,7 @@
 
 resource "azurerm_application_gateway" "app_gateway" {
   location            = var.location
-  name                = join("-", [var.application_gateway_abbreviation, var.application_gateway_name])
+  name                = join("-", compact([var.application_gateway_abbreviation, var.application_gateway_name]))
   resource_group_name = var.resource_group_name
   zones               = var.appgw_zones
   enable_http2        = var.enable_http2

--- a/modules/azurerm/Application-Gateway/subnet.tf
+++ b/modules/azurerm/Application-Gateway/subnet.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_subnet" "app_gateway_subnet" {
-  name                              = join("-", [var.subnet_abbreviation, var.application_gateway_subnet_name])
+  name                              = join("-", compact([var.subnet_abbreviation, var.application_gateway_subnet_name]))
   resource_group_name               = var.resource_group_name
   virtual_network_name              = var.virtual_network_name
   address_prefixes                  = var.address_prefixes

--- a/modules/azurerm/Application-Insights/application_insights.tf
+++ b/modules/azurerm/Application-Insights/application_insights.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_application_insights" "application_insights" {
-  name                                  = join("-", [var.application_insights_abbreviation, var.application_insights_name])
+  name                                  = join("-", compact([var.application_insights_abbreviation, var.application_insights_name]))
   location                              = var.location
   resource_group_name                   = var.resource_group_name
   application_type                      = var.application_type

--- a/modules/azurerm/CDN-FrontDoor-Route/cdn_frontdoor_route.tf
+++ b/modules/azurerm/CDN-FrontDoor-Route/cdn_frontdoor_route.tf
@@ -24,9 +24,9 @@ resource "azurerm_cdn_frontdoor_route" "cdn_frontdoor_route" {
   cdn_frontdoor_origin_group_id = var.cdn_frontdoor_origin_group_id
   cdn_frontdoor_origin_ids      = var.cdn_frontdoor_origin_ids
   #cdn_frontdoor_rule_set_ids    = var.cdn_frontdoor_rule_set_ids
-  enabled                       = var.enable_route
+  enabled = var.enable_route
 
-/*
+  /*
 Current route module does not provide the feature to set the priority order when attaching the rule sets,
 beacuse of that we had to use the azapi/FrontDoorRouteRuleSetOrderUpdate module and use az api to update the 
 route in front-door

--- a/modules/azurerm/Key-Vault/key_vault.tf
+++ b/modules/azurerm/Key-Vault/key_vault.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_key_vault" "key_vault" {
-  name                            = join("-", [var.key_vault_abbreviation, var.key_vault_name])
+  name                            = join("-", compact([var.key_vault_abbreviation, var.key_vault_name]))
   location                        = var.location
   resource_group_name             = var.resource_group_name
   sku_name                        = var.sku_name

--- a/modules/azurerm/Log-Analytics-Workspace/log_analytics_workspace.tf
+++ b/modules/azurerm/Log-Analytics-Workspace/log_analytics_workspace.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_log_analytics_workspace" "log_analytics_workspace" {
-  name                       = join("-", [var.log_analytics_abbreviation, var.log_analytics_workspace_name])
+  name                       = join("-", compact([var.log_analytics_abbreviation, var.log_analytics_workspace_name]))
   location                   = var.location
   resource_group_name        = var.resource_group_name
   sku                        = var.log_analytics_workspace_sku
@@ -27,7 +27,7 @@ resource "azurerm_log_analytics_solution" "log_analytics_solution" {
   location              = var.location
   resource_group_name   = var.resource_group_name
   workspace_resource_id = azurerm_log_analytics_workspace.log_analytics_workspace.id
-  workspace_name        = join("-", [var.log_analytics_abbreviation, var.log_analytics_workspace_name])
+  workspace_name        = join("-", compact([var.log_analytics_abbreviation, var.log_analytics_workspace_name]))
   depends_on = [
     azurerm_log_analytics_workspace.log_analytics_workspace
   ]

--- a/modules/azurerm/Monitor-Action-Groups/monitor_action_groups.tf
+++ b/modules/azurerm/Monitor-Action-Groups/monitor_action_groups.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_monitor_action_group" "monitor_action_group" {
-  name                = join("-", [var.monitor_action_group_abbreviation, var.montior_action_group_name])
+  name                = join("-", compact([var.monitor_action_group_abbreviation, var.montior_action_group_name]))
   resource_group_name = var.resource_group_name
   short_name          = var.short_name
   tags                = var.tags

--- a/modules/azurerm/Monitor-Log-Alerts/monitor_log_alerts.tf
+++ b/modules/azurerm/Monitor-Log-Alerts/monitor_log_alerts.tf
@@ -12,7 +12,7 @@
 resource "azurerm_monitor_activity_log_alert" "monitor_recommendation_alert" {
   for_each            = var.recommendation_alerts
   tags                = var.tags
-  name                = join("-", [var.monitor_activity_log_alert_abbreviation, each.value.alert_name])
+  name                = join("-", compact([var.monitor_activity_log_alert_abbreviation, each.value.alert_name]))
   resource_group_name = var.resource_group_name
   scopes              = each.value.scopes
   description         = each.value.description
@@ -33,7 +33,7 @@ resource "azurerm_monitor_activity_log_alert" "monitor_recommendation_alert" {
 resource "azurerm_monitor_activity_log_alert" "monitor_activity_log_alert" {
   for_each            = var.activity_log_alerts
   tags                = var.tags
-  name                = join("-", [var.monitor_activity_log_alert_abbreviation, each.value.alert_name])
+  name                = join("-", compact([var.monitor_activity_log_alert_abbreviation, each.value.alert_name]))
   resource_group_name = var.resource_group_name
   scopes              = each.value.scopes
   description         = each.value.description
@@ -54,7 +54,7 @@ resource "azurerm_monitor_activity_log_alert" "monitor_activity_log_alert" {
 resource "azurerm_monitor_activity_log_alert" "monitor_resource_health_alert" {
   for_each            = var.resource_health_alerts
   tags                = var.tags
-  name                = join("-", [var.monitor_activity_log_alert_abbreviation, each.value.alert_name])
+  name                = join("-", compact([var.monitor_activity_log_alert_abbreviation, each.value.alert_name]))
   resource_group_name = var.resource_group_name
   scopes              = each.value.scopes
   enabled             = each.value.query_enabled
@@ -84,7 +84,7 @@ resource "azurerm_monitor_activity_log_alert" "monitor_resource_health_alert" {
 resource "azurerm_monitor_activity_log_alert" "monitor_service_health_alert" {
   for_each            = var.service_health_alerts
   tags                = var.tags
-  name                = join("-", [var.monitor_activity_log_alert_abbreviation, each.value.alert_name])
+  name                = join("-", compact([var.monitor_activity_log_alert_abbreviation, each.value.alert_name]))
   resource_group_name = var.resource_group_name
   scopes              = each.value.scopes
   enabled             = each.value.query_enabled
@@ -109,7 +109,7 @@ resource "azurerm_monitor_activity_log_alert" "monitor_service_health_alert" {
 resource "azurerm_monitor_activity_log_alert" "monitor_specific_service_health_alert" {
   for_each            = var.specific_service_health_alerts
   tags                = var.tags
-  name                = join("-", [var.monitor_activity_log_alert_abbreviation, each.value.alert_name])
+  name                = join("-", compact([var.monitor_activity_log_alert_abbreviation, each.value.alert_name]))
   resource_group_name = var.resource_group_name
   scopes              = each.value.scopes
   enabled             = each.value.query_enabled

--- a/modules/azurerm/Monitor-Metric-Alerts/monitor_metrics_alerts.tf
+++ b/modules/azurerm/Monitor-Metric-Alerts/monitor_metrics_alerts.tf
@@ -11,7 +11,7 @@
 
 resource "azurerm_monitor_metric_alert" "monitor_metric_alert_with_2_dimensions" {
   for_each             = var.metric_alerts_with_2_dimensions
-  name                 = join("-", [var.monitor_metric_alert_abbreviation, each.value.alert_name])
+  name                 = join("-", compact([var.monitor_metric_alert_abbreviation, each.value.alert_name]))
   resource_group_name  = var.resource_group_name
   tags                 = var.tags
   scopes               = each.value.scopes
@@ -50,7 +50,7 @@ resource "azurerm_monitor_metric_alert" "monitor_metric_alert_with_2_dimensions"
 
 resource "azurerm_monitor_metric_alert" "monitor_metric_alert_with_1_dimension" {
   for_each             = var.metric_alerts_with_1_dimension
-  name                 = join("-", [var.monitor_metric_alert_abbreviation, each.value.alert_name])
+  name                 = join("-", compact([var.monitor_metric_alert_abbreviation, each.value.alert_name]))
   resource_group_name  = var.resource_group_name
   tags                 = var.tags
   scopes               = each.value.scopes
@@ -83,7 +83,7 @@ resource "azurerm_monitor_metric_alert" "monitor_metric_alert_with_1_dimension" 
 
 resource "azurerm_monitor_metric_alert" "monitor_metric_alert" {
   for_each                 = var.metric_alerts
-  name                     = join("-", [var.monitor_metric_alert_abbreviation, each.value.alert_name])
+  name                     = join("-", compact([var.monitor_metric_alert_abbreviation, each.value.alert_name]))
   resource_group_name      = var.resource_group_name
   tags                     = var.tags
   scopes                   = each.value.scopes

--- a/modules/azurerm/Monitor-Scheduled-Query-Alert-V1/monitor_scheduled_query_alert.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert-V1/monitor_scheduled_query_alert.tf
@@ -1,0 +1,76 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "scheduled_query_rules_alert" {
+  for_each            = var.query_rules_alert
+  name                = join("-", compact([var.scheduled_query_alert_abbreviation, each.value.alert_name]))
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  data_source_id      = each.value.log_analytics_workspace_id
+  description         = each.value.description
+  enabled             = each.value.query_enabled
+  query               = each.value.query
+  severity            = each.value.severity
+  frequency           = each.value.frequency
+  time_window         = each.value.time_window
+  tags                = merge(var.tags, { "enabled" : each.value.query_enabled })
+
+  action {
+    action_group           = each.value.action_group_id_list
+    custom_webhook_payload = each.value.custom_webhook_payload
+  }
+
+  trigger {
+    operator  = each.value.operator
+    threshold = each.value.threshold
+
+    metric_trigger {
+      operator            = each.value.metric_trigger_operator
+      threshold           = each.value.metric_threshold
+      metric_trigger_type = each.value.metric_trigger_type
+      metric_column       = each.value.metric_column
+    }
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "count_trigger_scheduled_query_rules_alert" {
+  for_each            = var.count_trigger_query_rules_alert
+  name                = join("-", compact([var.scheduled_query_alert_abbreviation, each.value.alert_name]))
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  data_source_id      = each.value.log_analytics_workspace_id
+  description         = each.value.description
+  enabled             = each.value.query_enabled
+  query               = each.value.query
+  severity            = each.value.severity
+  frequency           = each.value.frequency
+  time_window         = each.value.time_window
+  tags                = merge(var.tags, { "enabled" : each.value.query_enabled })
+
+  action {
+    action_group           = each.value.action_group_id_list
+    custom_webhook_payload = each.value.custom_webhook_payload
+  }
+
+  trigger {
+    operator  = each.value.operator
+    threshold = each.value.threshold
+  }
+}

--- a/modules/azurerm/Monitor-Scheduled-Query-Alert-V1/variables.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert-V1/variables.tf
@@ -1,0 +1,81 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "location" {
+  description = "The location where the Log Analytics Workspace should be created"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the Resource Group"
+  type        = string
+}
+
+variable "query_rules_alert" {
+  description = "Map of query rules alert"
+  type = map(object({
+    action_group_id_list       = list(string)
+    alert_name                 = string
+    log_analytics_workspace_id = string
+    description                = string
+    query_enabled              = bool
+    query                      = string
+    severity                   = number
+    frequency                  = number
+    time_window                = number
+    operator                   = string
+    threshold                  = number
+    metric_trigger_operator    = string
+    metric_threshold           = number
+    metric_trigger_type        = string
+    metric_column              = string
+    custom_webhook_payload     = optional(string)
+  }))
+}
+
+variable "count_trigger_query_rules_alert" {
+  description = "Map of count trigger query rules alert"
+  type = map(object({
+    action_group_id_list       = list(string)
+    alert_name                 = string
+    log_analytics_workspace_id = string
+    description                = string
+    query_enabled              = bool
+    query                      = string
+    severity                   = number
+    frequency                  = number
+    time_window                = number
+    operator                   = string
+    threshold                  = number
+    custom_webhook_payload     = optional(string)
+  }))
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to the resource."
+  type        = map(string)
+  default     = {}
+}
+
+variable "scheduled_query_alert_abbreviation" {
+  description = "Abbreviation for the scheduled query alert name"
+  type        = string
+  default     = "sqra"
+}

--- a/modules/azurerm/Monitor-Scheduled-Query-Alert-V1/versions.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert-V1/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.52.0"
+    }
+  }
+}

--- a/modules/azurerm/Monitor-Scheduled-Query-Alert/monitor_scheduled_query_alert.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert/monitor_scheduled_query_alert.tf
@@ -11,7 +11,7 @@
 
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "scheduled_query_rules_alert" {
   for_each             = var.query_rules_alert
-  name                 = join("-", ["sqra", each.value.alert_name])
+  name                 = join("-", compact([var.scheduled_query_alert_abbreviation, each.value.alert_name]))
   location             = var.location
   resource_group_name  = var.resource_group_name
   scopes               = each.value.scope_list
@@ -58,7 +58,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "scheduled_query_rules
 
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "count_trigger_scheduled_query_rules_alert" {
   for_each             = var.count_trigger_query_rules_alert
-  name                 = join("-", ["sqra", each.value.alert_name])
+  name                 = join("-", compact([var.scheduled_query_alert_abbreviation, each.value.alert_name]))
   location             = var.location
   resource_group_name  = var.resource_group_name
   scopes               = each.value.scope_list

--- a/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
@@ -71,3 +71,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "scheduled_query_alert_abbreviation" {
+  description = "Abbreviation for the scheduled query alert name"
+  type        = string
+  default     = "sqra"
+}

--- a/modules/azurerm/MySQL-Flexible-Server/mysql_flexible_server.tf
+++ b/modules/azurerm/MySQL-Flexible-Server/mysql_flexible_server.tf
@@ -1,0 +1,57 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_mysql_flexible_server" "mysql_server" {
+  name                         = join("-", compact([var.mysql_server_abbreviation, var.mysql_server_name]))
+  resource_group_name          = var.resource_group_name
+  location                     = var.location
+  administrator_login          = var.administrator_login
+  administrator_password       = var.administrator_password
+  backup_retention_days        = var.backup_retention_days
+  create_mode                  = var.create_mode
+  delegated_subnet_id          = azurerm_subnet.mysql_server_subnet.id
+  geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
+  private_dns_zone_id          = var.private_dns_zone_id
+  public_network_access        = var.public_network_access
+  replication_role             = var.replication_role
+  sku_name                     = var.sku_name
+  version                      = var.mysql_version
+  zone                         = var.zone
+  tags                         = var.tags
+
+  dynamic "high_availability" {
+    for_each = var.high_availability_enabled ? [1] : []
+    content {
+      mode                      = var.ha_mode
+      standby_availability_zone = var.ha_standby_availability_zone
+    }
+  }
+
+  dynamic "storage" {
+    for_each = var.storage_enabled ? [1] : []
+    content {
+      auto_grow_enabled   = var.storage_auto_grow_enabled
+      io_scaling_enabled  = var.storage_io_scaling_enabled
+      iops                = var.storage_iops
+      log_on_disk_enabled = var.storage_log_on_disk_enabled
+      size_gb             = var.storage_size_gb
+    }
+  }
+}

--- a/modules/azurerm/MySQL-Flexible-Server/outputs.tf
+++ b/modules/azurerm/MySQL-Flexible-Server/outputs.tf
@@ -1,0 +1,34 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "mysql_server_fqdn" {
+  depends_on = [azurerm_mysql_flexible_server.mysql_server]
+  value      = azurerm_mysql_flexible_server.mysql_server.fqdn
+}
+
+output "mysql_server_id" {
+  depends_on = [azurerm_mysql_flexible_server.mysql_server]
+  value      = azurerm_mysql_flexible_server.mysql_server.id
+}
+
+output "mysql_server_name" {
+  depends_on = [azurerm_mysql_flexible_server.mysql_server]
+  value      = azurerm_mysql_flexible_server.mysql_server.name
+}

--- a/modules/azurerm/MySQL-Flexible-Server/subnet.tf
+++ b/modules/azurerm/MySQL-Flexible-Server/subnet.tf
@@ -1,0 +1,40 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azurerm_subnet" "mysql_server_subnet" {
+  name                 = join("-", compact([var.subnet_abbreviation, var.subnet_name]))
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = var.virtual_network_name
+  address_prefixes     = var.address_prefix
+  service_endpoints    = var.service_endpoints
+
+  dynamic "delegation" {
+    for_each = var.delegations
+
+    content {
+      name = delegation.value.name
+
+      service_delegation {
+        name    = delegation.value.service_name
+        actions = delegation.value.actions
+      }
+    }
+  }
+}

--- a/modules/azurerm/MySQL-Flexible-Server/variables.tf
+++ b/modules/azurerm/MySQL-Flexible-Server/variables.tf
@@ -1,0 +1,200 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "mysql_server_abbreviation" {
+  description = "Abbreviation for the MySQL Flexible Server name"
+  type        = string
+  default     = "mysql"
+}
+
+variable "mysql_server_name" {
+  description = "Name of the MySQL Flexible Server"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Name of the resource group in which the MySQL Flexible Server will be created"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region where the MySQL Flexible Server will be created"
+  type        = string
+}
+
+variable "administrator_login" {
+  description = "Administrator login name for the MySQL Flexible Server"
+  type        = string
+}
+
+variable "administrator_password" {
+  description = "Administrator password for the MySQL Flexible Server"
+  type        = string
+  sensitive   = true
+}
+
+variable "backup_retention_days" {
+  description = "The number of days to retain backups for the MySQL Flexible Server. Valid values are between 7 and 35."
+  type        = number
+  default     = 7
+}
+
+variable "create_mode" {
+  description = "The mode to create the MySQL Flexible Server. Possible values are: 'Default', 'PointInTimeRestore', 'GeoRestore', 'Replica'"
+  type        = string
+  default     = "Default"
+}
+
+variable "geo_redundant_backup_enabled" {
+  description = "Specifies whether geo-redundant backup is enabled for the MySQL Flexible Server. Possible values are: true, false"
+  type        = bool
+  default     = false
+}
+
+variable "private_dns_zone_id" {
+  description = "The ID of the private DNS zone to link to the MySQL Flexible Server"
+  type        = string
+  default     = null
+}
+
+variable "public_network_access" {
+  description = "Specifies whether public network access is allowed for the MySQL Flexible Server. Possible values are: 'Enabled', 'Disabled'"
+  type        = string
+  default     = "Disabled"
+}
+
+variable "replication_role" {
+  description = "The replication role of the MySQL Flexible Server. Possible value is: 'None'"
+  type        = string
+  default     = "None"
+}
+
+variable "sku_name" {
+  description = "The SKU name of the MySQL Flexible Server"
+  type        = string
+}
+
+variable "mysql_version" {
+  description = "The MySQL version of the MySQL Flexible Server"
+  type        = string
+}
+
+variable "zone" {
+  description = "The availability zone of the MySQL Flexible Server"
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the MySQL Flexible Server"
+  type        = map(string)
+  default     = {}
+}
+
+variable "high_availability_enabled" {
+  description = "Specifies whether high availability is enabled for the MySQL Flexible Server"
+  type        = bool
+  default     = false
+}
+
+variable "ha_mode" {
+  description = "The high availability mode of the MySQL Flexible Server"
+  type        = string
+  default     = "ZoneRedundant"
+}
+
+variable "ha_standby_availability_zone" {
+  description = "The availability zone for the standby server when high availability is enabled for the MySQL Flexible Server"
+  type        = string
+  default     = null
+}
+
+variable "storage_enabled" {
+  description = "Specifies whether storage configuration is enabled for the MySQL Flexible Server"
+  type        = bool
+  default     = false
+}
+
+variable "storage_auto_grow_enabled" {
+  description = "Specifies whether auto-grow is enabled for the MySQL Flexible Server storage"
+  type        = bool
+  default     = false
+}
+
+variable "storage_io_scaling_enabled" {
+  description = "Specifies whether I/O scaling is enabled for the MySQL Flexible Server storage"
+  type        = bool
+  default     = false
+}
+
+variable "storage_iops" {
+  description = "The number of IOPS for the MySQL Flexible Server storage when I/O scaling is enabled"
+  type        = number
+  default     = null
+}
+
+variable "storage_log_on_disk_enabled" {
+  description = "Specifies whether log on disk is enabled for the MySQL Flexible Server storage"
+  type        = bool
+  default     = false
+}
+
+variable "storage_size_gb" {
+  description = "The storage size in GB for the MySQL Flexible Server when storage configuration is enabled"
+  type        = number
+  default     = null
+}
+
+variable "subnet_abbreviation" {
+  description = "Abbreviation for the subnet name"
+  type        = string
+  default     = "snet"
+}
+
+variable "subnet_name" {
+  description = "Name of the subnet to be created for the MySQL Flexible Server"
+  type        = string
+}
+
+variable "virtual_network_name" {
+  description = "Name of the virtual network in which the subnet will be created for the MySQL Flexible Server"
+  type        = string
+}
+
+variable "address_prefix" {
+  description = "The address prefix for the subnet to be created for the MySQL Flexible Server"
+  type        = list(string)
+}
+
+variable "service_endpoints" {
+  description = "The list of Service endpoints to associate with the subnet to be created for the MySQL Flexible Server"
+  type        = list(string)
+  default     = []
+}
+
+variable "delegations" {
+  description = "Delegation for the subnet to be created for the MySQL Flexible Server"
+  type = list(object({
+    name         = string,
+    service_name = string,
+    actions      = list(string)
+  }))
+  default = []
+}

--- a/modules/azurerm/MySQL-Flexible-Server/versions.tf
+++ b/modules/azurerm/MySQL-Flexible-Server/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.0.0"
+    }
+  }
+}

--- a/modules/azurerm/Private-EndPoint-Subnet/network_security_group.tf
+++ b/modules/azurerm/Private-EndPoint-Subnet/network_security_group.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_network_security_group" "private_network_security_group" {
-  name                = join("-", [var.nsg_abbreviation, var.network_security_group_name])
+  name                = join("-", compact([var.nsg_abbreviation, var.network_security_group_name]))
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/modules/azurerm/Private-EndPoint-Subnet/private_endpoint_subnet.tf
+++ b/modules/azurerm/Private-EndPoint-Subnet/private_endpoint_subnet.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_subnet" "private_endpoint_subnet" {
-  name                              = join("-", [var.private_endpoint_subnet_abbreviation, var.private_endpoint_subnet_name])
+  name                              = join("-", compact([var.private_endpoint_subnet_abbreviation, var.private_endpoint_subnet_name]))
   resource_group_name               = var.resource_group_name
   virtual_network_name              = var.virtual_network_name
   address_prefixes                  = [var.address_prefixes]

--- a/modules/azurerm/Private-EndPoint-Subnet/route_table.tf
+++ b/modules/azurerm/Private-EndPoint-Subnet/route_table.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_route_table" "private_endpoint_route_table" {
-  name                = join("-", [var.private_endpoint_subnet_route_table_abbreviation, var.private_endpoint_subnet_route_table_name])
+  name                = join("-", compact([var.private_endpoint_subnet_route_table_abbreviation, var.private_endpoint_subnet_route_table_name]))
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags

--- a/modules/azurerm/Private-Endpoint/private_endpoint.tf
+++ b/modules/azurerm/Private-Endpoint/private_endpoint.tf
@@ -10,21 +10,21 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_private_endpoint" "private_endpoint" {
-  name                = join("-", [var.private_endpoint_abbreviation, var.private_endpoint_name])
+  name                = join("-", compact([var.private_endpoint_abbreviation, var.private_endpoint_name]))
   location            = var.location
   resource_group_name = var.resource_group_name
   subnet_id           = var.private_endpoint_subnet_id
   tags                = var.tags
 
   private_service_connection {
-    name                           = join("-", [var.pvt_sc_abbreviation, var.private_endpoint_service_connection_name])
+    name                           = join("-", compact([var.pvt_sc_abbreviation, var.private_endpoint_service_connection_name]))
     private_connection_resource_id = var.private_connection_resource_id
     subresource_names              = var.subresource_names
     is_manual_connection           = false
   }
 
   private_dns_zone_group {
-    name                 = join("-", [var.pvt_dns_zone_group_abbreviation, var.private_endpoint_dns_zone_group_name])
+    name                 = join("-", compact([var.pvt_dns_zone_group_abbreviation, var.private_endpoint_dns_zone_group_name]))
     private_dns_zone_ids = var.private_dns_zone_ids
   }
 }

--- a/modules/azurerm/Public-IP/public_ip.tf
+++ b/modules/azurerm/Public-IP/public_ip.tf
@@ -10,13 +10,13 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_public_ip" "public_ip" {
-  name                    = join("-", [var.public_ip_abbreviation, var.public_ip_name])
+  name                    = join("-", compact([var.public_ip_abbreviation, var.public_ip_name]))
   resource_group_name     = var.resource_group_name
   location                = var.location
   allocation_method       = var.allocation_method
   ip_version              = var.ip_version
   sku                     = var.sku
   idle_timeout_in_minutes = var.idle_timeout_in_minutes
-  zones                   = [1, 2, 3]
+  zones                   = var.zones
   tags                    = var.tags
 }

--- a/modules/azurerm/Public-IP/variables.tf
+++ b/modules/azurerm/Public-IP/variables.tf
@@ -58,3 +58,9 @@ variable "public_ip_abbreviation" {
   type        = string
   default     = "pip"
 }
+
+variable "zones" {
+  description = "The availability zones of the Public IP."
+  type        = list(number)
+  default     = [1, 2, 3]
+}

--- a/modules/azurerm/Recovery-Services-Vault/recovery_services_vault.tf
+++ b/modules/azurerm/Recovery-Services-Vault/recovery_services_vault.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_recovery_services_vault" "recovery_services_vault" {
-  name                = join("-", [var.recovery_services_vault_abbreviation, var.recovery_services_vault_name])
+  name                = join("-", compact([var.recovery_services_vault_abbreviation, var.recovery_services_vault_name]))
   location            = var.location
   resource_group_name = var.resource_group_name
   sku                 = var.rs_vault_sku

--- a/modules/azurerm/Resource-Group/resource_group.tf
+++ b/modules/azurerm/Resource-Group/resource_group.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_resource_group" "resource_group" {
-  name     = join("-", [var.resource_group_abbreviation, var.resource_group_name])
+  name     = join("-", compact([var.resource_group_abbreviation, var.resource_group_name]))
   location = var.location
   tags     = var.tags
 }

--- a/modules/azurerm/Storage-Account-File/backup_policy_file_share.tf
+++ b/modules/azurerm/Storage-Account-File/backup_policy_file_share.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_backup_policy_file_share" "backup_policy_file_share" {
-  name                = join("-", [var.backup_policy_file_share_abbreviation, var.backup_policy_file_share_name])
+  name                = join("-", compact([var.backup_policy_file_share_abbreviation, var.backup_policy_file_share_name]))
   resource_group_name = var.resource_group_name
   recovery_vault_name = var.recovery_vault_name
 

--- a/modules/azurerm/Storage-Account-File/storage_account_file.tf
+++ b/modules/azurerm/Storage-Account-File/storage_account_file.tf
@@ -10,12 +10,12 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_storage_account" "storage_account" {
-  name                             = join("", [var.storage_account_abbreviation, var.storage_account_name])
+  name                             = join("", compact([var.storage_account_abbreviation, var.storage_account_name]))
   resource_group_name              = var.resource_group_name
   location                         = var.location
   account_tier                     = var.account_tier
   account_replication_type         = var.account_replication_type
-  account_kind                     = "FileStorage"
+  account_kind                     = var.account_kind
   https_traffic_only_enabled       = true
   min_tls_version                  = "TLS1_2"
   allow_nested_items_to_be_public  = var.allow_nested_items_to_be_public

--- a/modules/azurerm/Storage-Account-File/variables.tf
+++ b/modules/azurerm/Storage-Account-File/variables.tf
@@ -114,3 +114,9 @@ variable "cross_tenant_replication_enabled" {
   description = "Enable or disable cross tenant replication"
   type        = bool
 }
+
+variable "account_kind" {
+  description = "Defines the Kind of the storage account"
+  type        = string
+  default     = "FileStorage"
+}

--- a/modules/azurerm/Virtual-Network/private_dns_zone_virtual_network_link.tf
+++ b/modules/azurerm/Virtual-Network/private_dns_zone_virtual_network_link.tf
@@ -11,7 +11,7 @@
 
 resource "azurerm_private_dns_zone_virtual_network_link" "private_dns_zone_virtual_network_link" {
   count                 = length(var.private_dns_zones)
-  name                  = join("-", [var.private_dns_zone_vnet_link_abbreviation, var.private_dns_zones[count.index].name])
+  name                  = join("-", compact([var.private_dns_zone_vnet_link_abbreviation, var.private_dns_zones[count.index].name]))
   depends_on            = [azurerm_virtual_network.virtual_network]
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = var.private_dns_zones[count.index].zone_name

--- a/modules/azurerm/Virtual-Network/virtual_network.tf
+++ b/modules/azurerm/Virtual-Network/virtual_network.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_virtual_network" "virtual_network" {
-  name                = join("-", [var.virtual_network_abbreviation, var.virtual_network_name])
+  name                = join("-", compact([var.virtual_network_abbreviation, var.virtual_network_name]))
   address_space       = [var.virtual_network_address_space]
   location            = var.location
   resource_group_name = var.resource_group_name


### PR DESCRIPTION
### Description

This pull request introduces a new reusable Terraform module for creating Azure DevOps Docker Registry Service Endpoints and standardizes the naming conventions across multiple Azure resource modules by supporting customizable abbreviations. This improves both the flexibility and consistency of resource naming, making it easier to manage and identify resources in complex environments.

**New Azure DevOps Docker Registry Service Endpoint Module:**

* Added a new module in `modules/azuredevops/Docker-Registry-Service-Endpoint` to provision Docker Registry Service Endpoints in Azure DevOps, including resource definition, input variables, outputs, and provider version constraints. [[1]](diffhunk://#diff-9a33140212131a739f2d90d1d6223e875fde7be4a1d5ae28508f7eff6c1a51feR1-R30) [[2]](diffhunk://#diff-c8be116013b728b8dc5024e439f7db860385f40acb4fdc640874401118550c46R1-R64) [[3]](diffhunk://#diff-ae89c3002bb1952faf2b18ba40286454255f9d6dc26cad6ed281e448b23ebd23R1-R29) [[4]](diffhunk://#diff-aada6d88539672e572fd8ec90a746855d11e3d78cfd8cb261b1da11510330cd6R1-R29)

**Standardization and Customization of Resource Naming:**

* Updated AKS, Application Gateway, Application Insights, Key Vault, Log Analytics Workspace, Monitor Action Groups, Monitor Log Alerts, and Monitor Metric Alerts modules to use the `compact` function and new abbreviation variables in resource names, allowing for more flexible and consistent naming. [[1]](diffhunk://#diff-d8614663c1f5a403598dd5d2c325d0ec51d9cd91e527723a7a79829a69298881L13-R18) [[2]](diffhunk://#diff-d8614663c1f5a403598dd5d2c325d0ec51d9cd91e527723a7a79829a69298881L42-R42) [[3]](diffhunk://#diff-ba696ffd4de1acc64d54883808fb933a3444093cd13a0cc6095ab05185f6c097L13-R13) [[4]](diffhunk://#diff-ba696ffd4de1acc64d54883808fb933a3444093cd13a0cc6095ab05185f6c097L22-R22) [[5]](diffhunk://#diff-ba696ffd4de1acc64d54883808fb933a3444093cd13a0cc6095ab05185f6c097L46-R46) [[6]](diffhunk://#diff-705c023f12c610771d3f11f285059aa82eee030b754571e1684eb22f82529081L14-R14) [[7]](diffhunk://#diff-4b397c94003836c860ea1d31309f78dd3c19389b9687f80038342746e3491031L13-R13) [[8]](diffhunk://#diff-3378455160a7a3d20e5bab374dbd08bc970bc880fa7b09c0af955808a2a1d004L13-R13) [[9]](diffhunk://#diff-7112fe3af8366aa1c5aea813df39154f75153e0d706ea2a366b81e6fe1c9f97cL13-R13) [[10]](diffhunk://#diff-7112fe3af8366aa1c5aea813df39154f75153e0d706ea2a366b81e6fe1c9f97cL30-R30) [[11]](diffhunk://#diff-01e137dbab01d6ea6b0dd8012bc79edafcdd5bb77f5504ecd47072db52e07fcbL13-R13) [[12]](diffhunk://#diff-827a837598b0388ba2e41bf4022155325b8a845c1b881c3e0779147c6e7cacd9L15-R15) [[13]](diffhunk://#diff-827a837598b0388ba2e41bf4022155325b8a845c1b881c3e0779147c6e7cacd9L36-R36) [[14]](diffhunk://#diff-827a837598b0388ba2e41bf4022155325b8a845c1b881c3e0779147c6e7cacd9L57-R57) [[15]](diffhunk://#diff-827a837598b0388ba2e41bf4022155325b8a845c1b881c3e0779147c6e7cacd9L87-R87) [[16]](diffhunk://#diff-827a837598b0388ba2e41bf4022155325b8a845c1b881c3e0779147c6e7cacd9L112-R112) [[17]](diffhunk://#diff-85afb038f8544990d171b3c2b97e7ec2721c39b939c98630b817713e8df3f526L14-R14) [[18]](diffhunk://#diff-85afb038f8544990d171b3c2b97e7ec2721c39b939c98630b817713e8df3f526L53-R53)
* Introduced new variables for abbreviations in the AKS module to further control and customize the naming of clusters, node pools, subnets, route tables, and network security groups.