### PR TITLE
Add Azure DevOps agent pool module

### DIFF
--- a/modules/azuredevops/Agent-Pool/agent_pool.tf
+++ b/modules/azuredevops/Agent-Pool/agent_pool.tf
@@ -18,7 +18,7 @@
 #
 # --------------------------------------------------------------------------------------
 
-resource "azuredevops_agent_pool" "agent-pool" {
+resource "azuredevops_agent_pool" "agent_pool" {
   name           = var.agent_pool_name
   auto_provision = var.auto_provision
   auto_update    = var.auto_update

--- a/modules/azuredevops/Agent-Pool/agent_pool.tf
+++ b/modules/azuredevops/Agent-Pool/agent_pool.tf
@@ -1,0 +1,25 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azuredevops_agent_pool" "agent-pool" {
+  name           = var.agent_pool_name
+  auto_provision = var.auto_provision
+  auto_update    = var.auto_update
+}

--- a/modules/azuredevops/Agent-Pool/outputs.tf
+++ b/modules/azuredevops/Agent-Pool/outputs.tf
@@ -1,0 +1,24 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "agent_pool_id" {
+  description = "The ID of the Azure DevOps agent pool"
+  value       = azuredevops_agent_pool.agent-pool.id
+}

--- a/modules/azuredevops/Agent-Pool/outputs.tf
+++ b/modules/azuredevops/Agent-Pool/outputs.tf
@@ -20,5 +20,5 @@
 
 output "agent_pool_id" {
   description = "The ID of the Azure DevOps agent pool"
-  value       = azuredevops_agent_pool.agent-pool.id
+  value       = azuredevops_agent_pool.agent_pool.id
 }

--- a/modules/azuredevops/Agent-Pool/variables.tf
+++ b/modules/azuredevops/Agent-Pool/variables.tf
@@ -1,0 +1,37 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+
+variable "agent_pool_name" {
+  description = "Azure DevOps agent pool name"
+  type        = string
+}
+
+variable "auto_provision" {
+  description = "Whether to automatically provision agents in the pool"
+  type        = bool
+  default     = false
+}
+
+variable "auto_update" {
+  description = "Whether to automatically update agents in the pool"
+  type        = bool
+  default     = false
+}

--- a/modules/azuredevops/Agent-Pool/variables.tf
+++ b/modules/azuredevops/Agent-Pool/variables.tf
@@ -18,7 +18,6 @@
 #
 # --------------------------------------------------------------------------------------
 
-
 variable "agent_pool_name" {
   description = "Azure DevOps agent pool name"
   type        = string

--- a/modules/azuredevops/Agent-Pool/versions.tf
+++ b/modules/azuredevops/Agent-Pool/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azuredevops = {
+      source  = "microsoft/azuredevops"
+      version = ">= 0.7.0"
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

This pull request introduces a new Terraform module for managing Azure DevOps agent pools. The module includes resource definitions, input variables, outputs, and provider requirements, making it reusable and configurable for different environments.

**New Azure DevOps agent pool module:**

* Added the `azuredevops_agent_pool` resource in `agent_pool.tf` to create and manage an Azure DevOps agent pool, with configurable name, auto-provision, and auto-update options.
* Defined input variables in `variables.tf` for `agent_pool_name`, `auto_provision`, and `auto_update`, allowing users to customize the agent pool's behavior.
* Added an output `agent_pool_id` in `outputs.tf` to expose the created agent pool's ID.
* Specified Terraform and provider version requirements in `versions.tf` to ensure compatibility and stability.