### PR TITLE
Add optional fields for query validation and resource types

### DIFF
--- a/modules/azurerm/Monitor-Scheduled-Query-Alert/monitor_scheduled_query_alert.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert/monitor_scheduled_query_alert.tf
@@ -10,17 +10,19 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "scheduled_query_rules_alert" {
-  for_each             = var.query_rules_alert
-  name                 = join("-", compact([var.scheduled_query_alert_abbreviation, each.value.alert_name]))
-  location             = var.location
-  resource_group_name  = var.resource_group_name
-  scopes               = each.value.scope_list
-  description          = each.value.description
-  enabled              = each.value.query_enabled
-  severity             = each.value.severity
-  evaluation_frequency = each.value.evaluation_frequency
-  window_duration      = each.value.window_duration
-  tags                 = merge(var.tags, { "enabled" : each.value.query_enabled })
+  for_each              = var.query_rules_alert
+  name                  = join("-", compact([var.scheduled_query_alert_abbreviation, each.value.alert_name]))
+  location              = var.location
+  resource_group_name   = var.resource_group_name
+  scopes                = each.value.scope_list
+  description           = each.value.description
+  enabled               = each.value.query_enabled
+  severity              = each.value.severity
+  evaluation_frequency  = each.value.evaluation_frequency
+  window_duration       = each.value.window_duration
+  skip_query_validation = each.value.skip_query_validation
+  target_resource_types = each.value.target_resource_types
+  tags                  = merge(var.tags, { "enabled" : each.value.query_enabled })
 
   action {
     action_groups     = each.value.action_group_id_list
@@ -57,17 +59,19 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "scheduled_query_rules
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "count_trigger_scheduled_query_rules_alert" {
-  for_each             = var.count_trigger_query_rules_alert
-  name                 = join("-", compact([var.scheduled_query_alert_abbreviation, each.value.alert_name]))
-  location             = var.location
-  resource_group_name  = var.resource_group_name
-  scopes               = each.value.scope_list
-  description          = each.value.description
-  enabled              = each.value.query_enabled
-  severity             = each.value.severity
-  evaluation_frequency = each.value.evaluation_frequency
-  window_duration      = each.value.window_duration
-  tags                 = merge(var.tags, { "enabled" : each.value.query_enabled })
+  for_each              = var.count_trigger_query_rules_alert
+  name                  = join("-", compact([var.scheduled_query_alert_abbreviation, each.value.alert_name]))
+  location              = var.location
+  resource_group_name   = var.resource_group_name
+  scopes                = each.value.scope_list
+  description           = each.value.description
+  enabled               = each.value.query_enabled
+  severity              = each.value.severity
+  evaluation_frequency  = each.value.evaluation_frequency
+  window_duration       = each.value.window_duration
+  skip_query_validation = each.value.skip_query_validation
+  target_resource_types = each.value.target_resource_types
+  tags                  = merge(var.tags, { "enabled" : each.value.query_enabled })
 
   action {
     action_groups     = each.value.action_group_id_list

--- a/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
@@ -31,6 +31,8 @@ variable "query_rules_alert" {
     severity                = number
     evaluation_frequency    = string
     window_duration         = string
+    skip_query_validation   = optional(bool, false)
+    target_resource_types   = optional(list(string))
     operator                = string
     threshold               = number
     time_aggregation_method = string
@@ -51,18 +53,20 @@ variable "query_rules_alert" {
 variable "count_trigger_query_rules_alert" {
   description = "Map of count trigger query rules alert"
   type = map(object({
-    action_group_id_list = list(string)
-    alert_name           = string
-    scope_list           = list(string)
-    description          = string
-    query_enabled        = bool
-    query                = string
-    severity             = number
-    evaluation_frequency = string
-    window_duration      = string
-    operator             = string
-    threshold            = number
-    custom_properties    = optional(map(string))
+    action_group_id_list  = list(string)
+    alert_name            = string
+    scope_list            = list(string)
+    description           = string
+    query_enabled         = bool
+    query                 = string
+    severity              = number
+    evaluation_frequency  = string
+    window_duration       = string
+    skip_query_validation = optional(bool, false)
+    target_resource_types = optional(list(string))
+    operator              = string
+    threshold             = number
+    custom_properties     = optional(map(string))
   }))
 }
 


### PR DESCRIPTION
## Description

This pull request adds support for two new optional parameters, `skip_query_validation` and `target_resource_types`, to the Azure Monitor Scheduled Query Alert module. These changes make the alert configuration more flexible and customizable.

**Support for new alert configuration options:**

* Added `skip_query_validation` and `target_resource_types` as optional fields in the `query_rules_alert` and `count_trigger_query_rules_alert` input variable definitions, allowing users to control query validation and specify target resource types. [[1]](diffhunk://#diff-a1a23b93eca1aa37b1fa1cc46b2727cc9b5b9eb74c3082584a35aa81eaeb54faR34-R35) [[2]](diffhunk://#diff-a1a23b93eca1aa37b1fa1cc46b2727cc9b5b9eb74c3082584a35aa81eaeb54faR65-R66)
* Updated the `azurerm_monitor_scheduled_query_rules_alert_v2` resources to use the new `skip_query_validation` and `target_resource_types` parameters from the input variables. [[1]](diffhunk://#diff-2c67a1ccf4d6258aeb1d7c30434e75a887b826fe7beaa075d9880d233e3da277R23-R24) [[2]](diffhunk://#diff-2c67a1ccf4d6258aeb1d7c30434e75a887b826fe7beaa075d9880d233e3da277R72-R73)