### PR TITLE
[main] Add query_time_range_override to scheduled query alert variables

### DIFF
--- a/modules/azurerm/Monitor-Scheduled-Query-Alert/monitor_scheduled_query_alert.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert/monitor_scheduled_query_alert.tf
@@ -10,19 +10,20 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "scheduled_query_rules_alert" {
-  for_each              = var.query_rules_alert
-  name                  = join("-", compact([var.scheduled_query_alert_abbreviation, each.value.alert_name]))
-  location              = var.location
-  resource_group_name   = var.resource_group_name
-  scopes                = each.value.scope_list
-  description           = each.value.description
-  enabled               = each.value.query_enabled
-  severity              = each.value.severity
-  evaluation_frequency  = each.value.evaluation_frequency
-  window_duration       = each.value.window_duration
-  skip_query_validation = each.value.skip_query_validation
-  target_resource_types = each.value.target_resource_types
-  tags                  = merge(var.tags, { "enabled" : each.value.query_enabled })
+  for_each                  = var.query_rules_alert
+  name                      = join("-", compact([var.scheduled_query_alert_abbreviation, each.value.alert_name]))
+  location                  = var.location
+  resource_group_name       = var.resource_group_name
+  scopes                    = each.value.scope_list
+  description               = each.value.description
+  enabled                   = each.value.query_enabled
+  severity                  = each.value.severity
+  evaluation_frequency      = each.value.evaluation_frequency
+  window_duration           = each.value.window_duration
+  query_time_range_override = each.value.query_time_range_override
+  skip_query_validation     = each.value.skip_query_validation
+  target_resource_types     = each.value.target_resource_types
+  tags                      = merge(var.tags, { "enabled" : each.value.query_enabled })
 
   action {
     action_groups     = each.value.action_group_id_list
@@ -59,19 +60,20 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "scheduled_query_rules
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "count_trigger_scheduled_query_rules_alert" {
-  for_each              = var.count_trigger_query_rules_alert
-  name                  = join("-", compact([var.scheduled_query_alert_abbreviation, each.value.alert_name]))
-  location              = var.location
-  resource_group_name   = var.resource_group_name
-  scopes                = each.value.scope_list
-  description           = each.value.description
-  enabled               = each.value.query_enabled
-  severity              = each.value.severity
-  evaluation_frequency  = each.value.evaluation_frequency
-  window_duration       = each.value.window_duration
-  skip_query_validation = each.value.skip_query_validation
-  target_resource_types = each.value.target_resource_types
-  tags                  = merge(var.tags, { "enabled" : each.value.query_enabled })
+  for_each                  = var.count_trigger_query_rules_alert
+  name                      = join("-", compact([var.scheduled_query_alert_abbreviation, each.value.alert_name]))
+  location                  = var.location
+  resource_group_name       = var.resource_group_name
+  scopes                    = each.value.scope_list
+  description               = each.value.description
+  enabled                   = each.value.query_enabled
+  severity                  = each.value.severity
+  evaluation_frequency      = each.value.evaluation_frequency
+  window_duration           = each.value.window_duration
+  query_time_range_override = each.value.query_time_range_override
+  skip_query_validation     = each.value.skip_query_validation
+  target_resource_types     = each.value.target_resource_types
+  tags                      = merge(var.tags, { "enabled" : each.value.query_enabled })
 
   action {
     action_groups     = each.value.action_group_id_list

--- a/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
+++ b/modules/azurerm/Monitor-Scheduled-Query-Alert/variables.tf
@@ -22,20 +22,21 @@ variable "resource_group_name" {
 variable "query_rules_alert" {
   description = "Map of query rules alert"
   type = map(object({
-    action_group_id_list    = list(string)
-    alert_name              = string
-    scope_list              = list(string)
-    description             = string
-    query_enabled           = bool
-    query                   = string
-    severity                = number
-    evaluation_frequency    = string
-    window_duration         = string
-    skip_query_validation   = optional(bool, false)
-    target_resource_types   = optional(list(string))
-    operator                = string
-    threshold               = number
-    time_aggregation_method = string
+    action_group_id_list      = list(string)
+    alert_name                = string
+    scope_list                = list(string)
+    description               = string
+    query_enabled             = bool
+    query                     = string
+    severity                  = number
+    evaluation_frequency      = string
+    window_duration           = string
+    query_time_range_override = optional(string)
+    skip_query_validation     = optional(bool, false)
+    target_resource_types     = optional(list(string))
+    operator                  = string
+    threshold                 = number
+    time_aggregation_method   = string
     dimension = list(object({
       name     = string
       operator = string
@@ -53,20 +54,21 @@ variable "query_rules_alert" {
 variable "count_trigger_query_rules_alert" {
   description = "Map of count trigger query rules alert"
   type = map(object({
-    action_group_id_list  = list(string)
-    alert_name            = string
-    scope_list            = list(string)
-    description           = string
-    query_enabled         = bool
-    query                 = string
-    severity              = number
-    evaluation_frequency  = string
-    window_duration       = string
-    skip_query_validation = optional(bool, false)
-    target_resource_types = optional(list(string))
-    operator              = string
-    threshold             = number
-    custom_properties     = optional(map(string))
+    action_group_id_list      = list(string)
+    alert_name                = string
+    scope_list                = list(string)
+    description               = string
+    query_enabled             = bool
+    query                     = string
+    severity                  = number
+    evaluation_frequency      = string
+    window_duration           = string
+    query_time_range_override = optional(string)
+    skip_query_validation     = optional(bool, false)
+    target_resource_types     = optional(list(string))
+    operator                  = string
+    threshold                 = number
+    custom_properties         = optional(map(string))
   }))
 }
 


### PR DESCRIPTION
## Description

This pull request adds support for the optional `query_time_range_override` property to both standard and count trigger scheduled query alert resources in the Azure Monitor Scheduled Query Alert Terraform module. This allows users to override the default time range used for queries in alert rules.

**Support for `query_time_range_override`:**

* Added the `query_time_range_override` property to the `azurerm_monitor_scheduled_query_rules_alert_v2` resource configuration, allowing its value to be set from input variables. [[1]](diffhunk://#diff-2c67a1ccf4d6258aeb1d7c30434e75a887b826fe7beaa075d9880d233e3da277R23) [[2]](diffhunk://#diff-2c67a1ccf4d6258aeb1d7c30434e75a887b826fe7beaa075d9880d233e3da277R73)
* Updated the `query_rules_alert` and `count_trigger_query_rules_alert` variable definitions to include `query_time_range_override` as an optional string input. [[1]](diffhunk://#diff-a1a23b93eca1aa37b1fa1cc46b2727cc9b5b9eb74c3082584a35aa81eaeb54faR34) [[2]](diffhunk://#diff-a1a23b93eca1aa37b1fa1cc46b2727cc9b5b9eb74c3082584a35aa81eaeb54faR66)