### PR TITLE
Add `undrainable_node_behavior` variable for node pool upgrades

### DIFF
--- a/modules/azurerm/AKS-Node-Pool/aks_node_pool.tf
+++ b/modules/azurerm/AKS-Node-Pool/aks_node_pool.tf
@@ -32,6 +32,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "kubernetes_cluster_node_pool" {
     drain_timeout_in_minutes      = var.node_pool_upgrade_drain_timeout
     node_soak_duration_in_minutes = var.node_pool_upgrade_soak_duration
     max_surge                     = var.node_pool_upgrade_max_surge
+    undrainable_node_behavior     = var.node_pool_upgrade_undrainable_node_behavior
   }
 
   lifecycle {

--- a/modules/azurerm/AKS-Node-Pool/variables.tf
+++ b/modules/azurerm/AKS-Node-Pool/variables.tf
@@ -110,3 +110,9 @@ variable "node_pool_upgrade_max_surge" {
   description = "Maximum surge for node pool upgrades"
   type        = string
 }
+
+variable "node_pool_upgrade_undrainable_node_behavior" {
+  default     = null
+  description = "Behavior for undrainable nodes during node pool upgrades"
+  type        = string
+}


### PR DESCRIPTION
### Description

This pull request adds support for configuring the behavior of undrainable nodes during AKS node pool upgrades. A new variable is introduced to allow users to specify the desired behavior, and this variable is now passed to the resource definition.

Configuration enhancements for AKS node pool upgrades:

* Added a new variable `node_pool_upgrade_undrainable_node_behavior` to allow customization of the behavior for undrainable nodes during upgrades in `variables.tf`.
* Passed the new `undrainable_node_behavior` variable to the `azurerm_kubernetes_cluster_node_pool` resource in `aks_node_pool.tf`.