### PR TITLE
Refactor CDN Front Door resource name variables

### DIFF
--- a/modules/azurerm/CDN-FrontDoor-Custom-Domain/cdn_frontdoor_custom_domain.tf
+++ b/modules/azurerm/CDN-FrontDoor-Custom-Domain/cdn_frontdoor_custom_domain.tf
@@ -19,7 +19,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_cdn_frontdoor_custom_domain" "cdn_frontdoor_custom_domain" {
-  name                     = join("-", [var.custom_domain_name, var.custom_domain_suffix])
+  name                     = join("-", compact([var.custom_domain_name, var.custom_domain_suffix]))
   cdn_frontdoor_profile_id = var.cdn_frontdoor_profile_id
   dns_zone_id              = var.dns_zone_id
   host_name                = var.host_name

--- a/modules/azurerm/CDN-FrontDoor-Origin-Group/cdn_frontdoor_origin_group.tf
+++ b/modules/azurerm/CDN-FrontDoor-Origin-Group/cdn_frontdoor_origin_group.tf
@@ -19,7 +19,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "azurerm_cdn_frontdoor_origin_group" "cdn_frontdoor_origin_group" {
-  name                     = join("-", [var.origin_group_name, var.origin_group_suffix])
+  name                     = join("-", compact([var.origin_group_name, var.origin_group_suffix]))
   cdn_frontdoor_profile_id = var.cdn_frontdoor_profile_id
   session_affinity_enabled = var.enable_session_affinity
 


### PR DESCRIPTION
## Description

This pull request makes a small but important improvement to how resource names are constructed in two Azure CDN FrontDoor Terraform modules. The main change is to ensure that resource names do not include empty string components, which could cause issues with naming conventions or resource creation.

Naming improvements:

* Updated the `name` attribute in both `azurerm_cdn_frontdoor_custom_domain` and `azurerm_cdn_frontdoor_origin_group` resources to use the `compact` function. This removes any empty strings from the list before joining, preventing unintended dashes or malformed names. [[1]](diffhunk://#diff-523d63b1955a1f677a237a5881a429fab0cf74e433607f464fad41883fa1ba15L22-R22) [[2]](diffhunk://#diff-160f85e06baeac4ed5435e350c85b8dd61ff5277cad4f14f384fce0940a014d0L22-R22)