### PR TITLE
Add opt-in MSI auth for AKS-Firewall Container Insights (oms_agent)

### DIFF
--- a/modules/azurerm/AKS-Firewall/aks_cluster.tf
+++ b/modules/azurerm/AKS-Firewall/aks_cluster.tf
@@ -102,7 +102,8 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
   }
 
   oms_agent {
-    log_analytics_workspace_id = var.log_analytics_workspace_id
+    log_analytics_workspace_id      = var.log_analytics_workspace_id
+    msi_auth_for_monitoring_enabled = var.msi_auth_for_monitoring_enabled
   }
 
   network_profile {

--- a/modules/azurerm/AKS-Firewall/variables.tf
+++ b/modules/azurerm/AKS-Firewall/variables.tf
@@ -184,6 +184,12 @@ variable "log_analytics_workspace_id" {
   type        = string
 }
 
+variable "msi_auth_for_monitoring_enabled" {
+  description = "Enable MSI auth for monitoring"
+  type        = bool
+  default     = false
+}
+
 variable "azure_policy_enabled" {
   description = "Enable Azure policy"
   type        = bool


### PR DESCRIPTION
# Pull Request

## Purpose

The `AKS-Firewall` module's `oms_agent` (Container Insights addon) block only sets
`log_analytics_workspace_id` and does not expose
`msi_auth_for_monitoring_enabled`, causing the addon to default to legacy
workspace-key authentication (`useAADAuth=false`). This authentication mode only
supports ingestion into the deprecated `ContainerLog` (V1) table.

`ContainerLogV2` requires DCR-based ingestion, which in turn requires
managed-identity (MSI) authentication. Microsoft has retired legacy
authentication, and the `ContainerLog` (V1) table retires on **30 September
2026**.

The sibling `AKS-Generic` module already exposes this option. This PR brings
`AKS-Firewall` to feature parity.


## Goals

Allow consumers of the `AKS-Firewall` module to opt in to managed-identity
authentication for the Container Insights addon so clusters can write to
`ContainerLogV2`, while preserving existing behaviour by default.

## Approach

- Added a new boolean variable
  `msi_auth_for_monitoring_enabled` (default `false`) to
  `modules/azurerm/AKS-Firewall/variables.tf`.
- Wired the variable into the `oms_agent` block in
  `modules/azurerm/AKS-Firewall/aks_cluster.tf` as:
  ```hcl
  msi_auth_for_monitoring_enabled = var.msi_auth_for_monitoring_enabled
  ```
- Used the same variable name, type, default value, and description as the
  existing implementation in `AKS-Generic` for consistency.
- The default value (`false`) matches the AzureRM provider default, so existing
  consumers see no Terraform plan changes and continue using legacy
  workspace-key authentication.
- When set to `true`, the addon switches to managed-identity authentication
  (`useAADAuth=true`), allowing Azure Monitor to ingest logs through a Data
  Collection Rule and write to `ContainerLogV2`.
- No workspace lookup or additional data sources were introduced. The Log
  Analytics workspace ID continues to be supplied by the consuming module.

## User stories

As a platform engineer, I want to enable managed-identity authentication for
Container Insights on a specific AKS cluster so that it writes to the
`ContainerLogV2` table while leaving all other clusters unchanged.

## Release note

Added the `msi_auth_for_monitoring_enabled` variable to the `AKS-Firewall`
module to optionally enable managed-identity authentication for the Container
Insights addon. The variable defaults to `false` for full backward
compatibility and aligns with the existing implementation in `AKS-Generic`.

## Documentation

N/A — Internal Terraform module. Behaviour is documented through the variable
description. No customer-facing documentation changes are required.

## Training

N/A

## Certification

N/A — Infrastructure module change with no certification impact.

## Marketing

N/A

## Automation tests

- **Unit tests**
  > N/A — Terraform module; no unit test framework exists in this repository.

- **Integration tests**
  > Executed `terraform fmt` and `terraform validate` successfully.
  >
  > Verified an in-place update (`false` → `true`) in the consuming repository
  > on the Asgardeo development cluster. No cluster or node pool recreation was
  > required.

## Security checks

- Followed secure coding standards?
  > Yes.

- Ran FindSecurityBugs?
  > N/A — Terraform project.

- Confirmed that no credentials, secrets, or tokens were introduced?
  > Yes. This change reduces reliance on workspace shared keys by enabling
  > identity-based authentication.

## Samples

N/A

## Related PRs

- Consuming repository change (`asgardeo-deployment`) to bump the module
  version and enable `msi_auth_for_monitoring_enabled` for the development
  cluster (link to be added).

## Migrations (if applicable)

No migration is required for existing consumers because the default value
remains `false`, resulting in no Terraform plan changes.

To opt in:

- Upgrade to the new module version.
- Set `msi_auth_for_monitoring_enabled = true`.

Terraform performs an in-place update by changing:

```text
oms_agent[0].msi_auth_for_monitoring_enabled:
false -> true
```

No AKS cluster or node pool recreation is required.

The cluster's managed identity must have the **Monitoring Metrics Publisher**
role on the target Log Analytics workspace/Data Collection Rule for MSI-based
ingestion.

Validated on the Asgardeo development cluster.

## Test environment

- Terraform CLI
- AzureRM provider >= 4.21.0
- Module: `modules/azurerm/AKS-Firewall`
- Azure AKS (Asgardeo development cluster)

## Learning

Reviewed Microsoft's Container Insights authentication model and
`ContainerLogV2` requirements:

- https://learn.microsoft.com/azure/azure-monitor/containers/container-insights-authentication
- https://learn.microsoft.com/azure/azure-monitor/containers/container-insights-logs-schema

Confirmed that:

- `ContainerLogV2` is only written through DCR-based ingestion.
- DCR-based ingestion requires managed-identity authentication.
- Legacy workspace-key authentication only supports `ContainerLog`.
- The `ContainerLog` table retires on **30 September 2026**.
- The AzureRM provider exposes `msi_auth_for_monitoring_enabled` for the
  `oms_agent` block.