### PR TITLE
Add Group and Build-Definition-Permissions azuredevops modules

### DIFF
--- a/modules/azuredevops/Build-Definition-Permissions/build_definition_permissions.tf
+++ b/modules/azuredevops/Build-Definition-Permissions/build_definition_permissions.tf
@@ -1,0 +1,27 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azuredevops_build_definition_permissions" "build_definition_permissions" {
+  project_id          = var.project_id
+  principal           = var.principal
+  build_definition_id = var.build_definition_id
+  permissions         = var.permissions
+  replace             = var.replace
+}

--- a/modules/azuredevops/Build-Definition-Permissions/variables.tf
+++ b/modules/azuredevops/Build-Definition-Permissions/variables.tf
@@ -1,0 +1,45 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "project_id" {
+  description = "The ID of the project to assign the permissions in."
+  type        = string
+}
+
+variable "principal" {
+  description = "The group principal to assign the permissions to. Individual user/service principal descriptors are not supported by this resource; use a group descriptor."
+  type        = string
+}
+
+variable "build_definition_id" {
+  description = "The ID of the build definition to assign the permissions to."
+  type        = string
+}
+
+variable "permissions" {
+  description = "A map of permissions to assign. Each value must be Allow, Deny, or NotSet. Valid keys: ViewBuilds, EditBuildQuality, RetainIndefinitely, DeleteBuilds, ManageBuildQualities, DestroyBuilds, UpdateBuildInformation, QueueBuilds, ManageBuildQueue, StopBuilds, ViewBuildDefinition, EditBuildDefinition, DeleteBuildDefinition, OverrideBuildCheckInValidation, AdministerBuildPermissions, CreateBuildDefinition, EditPipelineQueueConfigurationPermission."
+  type        = map(string)
+}
+
+variable "replace" {
+  description = "Replace (true) or merge (false) the permissions with any already set on the build definition."
+  type        = bool
+  default     = true
+}

--- a/modules/azuredevops/Build-Definition-Permissions/variables.tf
+++ b/modules/azuredevops/Build-Definition-Permissions/variables.tf
@@ -34,8 +34,13 @@ variable "build_definition_id" {
 }
 
 variable "permissions" {
-  description = "A map of permissions to assign. Each value must be Allow, Deny, or NotSet. Valid keys: ViewBuilds, EditBuildQuality, RetainIndefinitely, DeleteBuilds, ManageBuildQualities, DestroyBuilds, UpdateBuildInformation, QueueBuilds, ManageBuildQueue, StopBuilds, ViewBuildDefinition, EditBuildDefinition, DeleteBuildDefinition, OverrideBuildCheckInValidation, AdministerBuildPermissions, CreateBuildDefinition, EditPipelineQueueConfigurationPermission."
+  description = "A map of permissions to assign. Each value must be Allow or Deny. Valid keys: ViewBuilds, EditBuildQuality, RetainIndefinitely, DeleteBuilds, ManageBuildQualities, DestroyBuilds, UpdateBuildInformation, QueueBuilds, ManageBuildQueue, StopBuilds, ViewBuildDefinition, EditBuildDefinition, DeleteBuildDefinition, OverrideBuildCheckInValidation, AdministerBuildPermissions, CreateBuildDefinition, EditPipelineQueueConfigurationPermission."
   type        = map(string)
+
+  validation {
+    condition     = alltrue([for v in values(var.permissions) : contains(["Allow", "Deny"], v)])
+    error_message = "Each permission value must be one of: Allow, Deny."
+  }
 }
 
 variable "replace" {

--- a/modules/azuredevops/Build-Definition-Permissions/versions.tf
+++ b/modules/azuredevops/Build-Definition-Permissions/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azuredevops = {
+      source  = "microsoft/azuredevops"
+      version = ">= 0.1.1"
+    }
+  }
+}

--- a/modules/azuredevops/Group/group.tf
+++ b/modules/azuredevops/Group/group.tf
@@ -1,0 +1,28 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "azuredevops_group" "devops_group" {
+  scope        = var.scope
+  display_name = var.display_name
+  origin_id    = var.origin_id
+  mail         = var.mail
+  description  = var.description
+  members      = var.members
+}

--- a/modules/azuredevops/Group/outputs.tf
+++ b/modules/azuredevops/Group/outputs.tf
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "id" {
+  description = "The ID of the Group."
+  depends_on  = [azuredevops_group.devops_group]
+  value       = azuredevops_group.devops_group.id
+}
+
+output "descriptor" {
+  description = "The identity (subject) descriptor of the Group."
+  depends_on  = [azuredevops_group.devops_group]
+  value       = azuredevops_group.devops_group.descriptor
+}

--- a/modules/azuredevops/Group/variables.tf
+++ b/modules/azuredevops/Group/variables.tf
@@ -22,12 +22,22 @@ variable "scope" {
   description = "The scope of the group. A descriptor referencing the scope (collection, project) in which the group should be created. If omitted, will be created in the scope of the enclosing account or organization. Cannot be used simultaneously with origin_id or mail."
   type        = string
   default     = null
+
+  validation {
+    condition     = var.scope == null || (var.origin_id == null && var.mail == null)
+    error_message = "scope cannot be used simultaneously with origin_id or mail."
+  }
 }
 
 variable "display_name" {
-  description = "The name of a new Azure DevOps group that is not backed by an external provider. Cannot be used simultaneously with origin_id or mail."
+  description = "The name of a new Azure DevOps group that is not backed by an external provider. Cannot be used simultaneously with origin_id or mail. Exactly one of display_name, origin_id, or mail must be set."
   type        = string
   default     = null
+
+  validation {
+    condition     = length([for v in [var.display_name, var.origin_id, var.mail] : v if v != null]) == 1
+    error_message = "Exactly one of display_name, origin_id, or mail must be set."
+  }
 }
 
 variable "origin_id" {

--- a/modules/azuredevops/Group/variables.tf
+++ b/modules/azuredevops/Group/variables.tf
@@ -1,0 +1,55 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "scope" {
+  description = "The scope of the group. A descriptor referencing the scope (collection, project) in which the group should be created. If omitted, will be created in the scope of the enclosing account or organization. Cannot be used simultaneously with origin_id or mail."
+  type        = string
+  default     = null
+}
+
+variable "display_name" {
+  description = "The name of a new Azure DevOps group that is not backed by an external provider. Cannot be used simultaneously with origin_id or mail."
+  type        = string
+  default     = null
+}
+
+variable "origin_id" {
+  description = "The OriginID as a reference to a group from an external AD or AAD backed provider. Cannot be used simultaneously with scope, mail, or display_name."
+  type        = string
+  default     = null
+}
+
+variable "mail" {
+  description = "The mail address as a reference to an existing group from an external AD or AAD backed provider. Cannot be used simultaneously with scope, origin_id, or display_name."
+  type        = string
+  default     = null
+}
+
+variable "description" {
+  description = "The description of the group."
+  type        = string
+  default     = null
+}
+
+variable "members" {
+  description = "The descriptors of the members of the group. Cannot be used together with the azuredevops_group_membership resource for the same group, since the two ways of managing membership will conflict."
+  type        = list(string)
+  default     = null
+}

--- a/modules/azuredevops/Group/versions.tf
+++ b/modules/azuredevops/Group/versions.tf
@@ -19,7 +19,7 @@
 # --------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.9.0"
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"

--- a/modules/azuredevops/Group/versions.tf
+++ b/modules/azuredevops/Group/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    azuredevops = {
+      source  = "microsoft/azuredevops"
+      version = ">= 0.1.0"
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request

## Purpose

Neither `azuredevops_group` nor `azuredevops_build_definition_permissions` has awrapping module in this repo. Consumers who need to create an ADO group and grant it permissions on a specific build definition are forced to fall back to raw provider resources, breaking from this repo's module-abstraction convention for everything else in `modules/azuredevops`.

This gap was hit directly when needs to grant an external Asgardeo service principal `QueueBuilds`/`ViewBuilds`/`ViewBuildDefinition` on one specific pipeline via a dedicated group. Azure DevOps only accepts group principals for build-definition permissions, not individual users/SPs. A full-repo content search confirmed no existing module covers either resource.

## Goals

Let consumers create an Azure DevOps group and grant it build-definition-level permissions using first-class modules, consistent with how every other `azuredevops` resource in this repo is already wrapped (e.g.
`Service-Principal-Entitlement`, `Group-Membership`, `Project`).

## Approach

- Added `modules/azuredevops/Group`, wrapping `azuredevops_group`
  (`group.tf`, `variables.tf`, `outputs.tf`, `versions.tf`). Exposes all
  provider arguments (`scope`, `display_name`, `origin_id`, `mail`,
  `description`, `members`) and outputs `id` and `descriptor`.
- Added `modules/azuredevops/Build-Definition-Permissions`, wrapping
  `azuredevops_build_definition_permissions` (`build_definition_permissions.tf`,
  `variables.tf`, `versions.tf`). Exposes `project_id`, `principal`,
  `build_definition_id`, `permissions`, and `replace`.
- Followed the structure and license header used by the most recently added
  modules in this repo (`Service-Principal-Entitlement`, `Group-Membership`):
  one resource file, `variables.tf`, `versions.tf`, and `outputs.tf` only
  where the resource exposes something worth surfacing.
- Provider version constraints pinned to the minimum version each resource
  was introduced in, per the [provider CHANGELOG](https://github.com/microsoft/terraform-provider-azuredevops/blob/main/CHANGELOG.md):
  - `azuredevops_group` — `>= 0.1.0` (introduced 0.0.1)
  - `azuredevops_build_definition_permissions` — `>= 0.1.1` (introduced 0.1.1)
- No new resource types beyond the two provider resources being wrapped; no
  data sources or extra abstraction added.

## User stories

As a platform engineer, I want to grant an external service principal permission to queue and view one specific pipeline - via a dedicated ADO group, since build-definition permissions can't target a principal directly - using standard modules instead of raw provider resources, so my Terraform stays consistent with the rest of this repo's module abstractions.

## Release note

Added `modules/azuredevops/Group` and `modules/azuredevops/Build-Definition-Permissions`, wrapping `azuredevops_group` and `azuredevops_build_definition_permissions` respectively.

## Documentation

N/A — Internal Terraform module. Behaviour is documented through variable descriptions. No customer-facing documentation changes are required.

## Training

N/A

## Certification

N/A — Infrastructure module change with no certification impact.

## Marketing

N/A

## Automation tests

- **Unit tests**
  > N/A — Terraform module; no unit test framework exists in this repository.

- **Integration tests**
  > Ran `terraform fmt -check -diff` and `terraform validate` successfully on
  > both modules (`-backend=false` init).
  >
  > No live `apply` was run against this repo directly — these are new,
  > unused modules. Consumption is validated end-to-end in the companion
  > downstream change (see Related PRs), which replaces the equivalent raw
  > resource blocks with these modules.

## Security checks

- Followed secure coding standards?
  > Yes.

- Ran FindSecurityBugs?
  > N/A — Terraform project.

- Confirmed that no credentials, secrets, or tokens were introduced?
  > Yes. These modules only wrap identity/permission-management resources
  > (group membership, pipeline permissions) — no secrets, keys, or tokens
  > are handled or exposed.

## Samples

N/A

## Migrations (if applicable)

No migration required — these are new modules with no existing consumers. Downstream repos currently using the equivalent raw resource blocks can switch to these modules at their own pace; doing so is a state-only change
(`moved` block or resource re-address) with no infrastructure recreation, since the underlying resource types and arguments are unchanged.

## Test environment

- Terraform CLI
- `microsoft/azuredevops` provider
- Modules: `modules/azuredevops/Group`,
  `modules/azuredevops/Build-Definition-Permissions`

## Learning

Reviewed the official [`azuredevops_group`](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/group)
and [`azuredevops_build_definition_permissions`](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition_permissions)
provider docs, and the provider CHANGELOG to determine the minimum version
each resource was introduced in. Confirmed:

- `azuredevops_build_definition_permissions.principal` only accepts a group
  descriptor — individual user/service-principal descriptors are rejected.
- `azuredevops_group`'s `scope`, `origin_id`, and `mail` arguments are
  mutually exclusive with each other and with `display_name` in different
  combinations, per the provider docs — surfaced as-is via optional,
  independently nullable variables rather than adding validation logic that
  would duplicate the provider's own enforcement.


